### PR TITLE
#13: Insert empty nodes (insertion / deletion) in DNA sequence graph

### DIFF
--- a/src/main/java/nl/tudelft/lifetiles/graph/DefaultGraphParser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/DefaultGraphParser.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import nl.tudelft.lifetiles.graph.sequence.SegmentString;
 import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 /**
@@ -110,7 +111,7 @@ public class DefaultGraphParser implements GraphParser {
         Collections.addAll(s, sources);
 
         return new SequenceSegment(s, Integer.parseInt(desc[START_POS].trim()),
-                Integer.parseInt(desc[END_POS].trim()), content.trim());
+                Integer.parseInt(desc[END_POS].trim()), new SegmentString(content.trim()));
 
     }
 

--- a/src/main/java/nl/tudelft/lifetiles/graph/DefaultGraphParser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/DefaultGraphParser.java
@@ -9,6 +9,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
+
 /**
  * @author Rutger van den Berg
  *

--- a/src/main/java/nl/tudelft/lifetiles/graph/Graph.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/Graph.java
@@ -80,4 +80,14 @@ public interface Graph<V> {
      *            Id of the destination vertex.
      */
     void addEdge(int source, int destination);
+
+    /**
+     * Divides an edge into two edges with an inserted vertex in the middle.
+     * 
+     * @param edge
+     *            Edge to be divided.
+     * @param vertex
+     *            Vertex to be inserted.
+     */
+	void divideEdge(Edge<V> edge, V vertex);
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/GraphParser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/GraphParser.java
@@ -1,5 +1,7 @@
 package nl.tudelft.lifetiles.graph;
 
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
+
 /**
  * @author Rutger van den Berg Interface for Graph Parser.
  */

--- a/src/main/java/nl/tudelft/lifetiles/graph/ParserFactory.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/ParserFactory.java
@@ -1,5 +1,7 @@
 package nl.tudelft.lifetiles.graph;
 
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
+
 /**
  * Interface for ParserFactory. Implementations will parse various files into a
  * graph.

--- a/src/main/java/nl/tudelft/lifetiles/graph/SequenceSegment.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/SequenceSegment.java
@@ -41,6 +41,18 @@ public class SequenceSegment {
         endVar = endPosition;
         contentVar = content;
     }
+    
+    /**
+     * Returns the distance between this sequence segment and another.
+     * (non-euclidian distance)
+     * @param other
+     *            Sequence segment which needs to be compared.
+     * @return
+     *            Distance between this sequence and other sequence.
+     */
+    public long distanceTo(SequenceSegment other) {
+		return other.getStart() - getEnd() - 1;
+    }
 
     /**
      * @return the sources

--- a/src/main/java/nl/tudelft/lifetiles/graph/jgrapht/JGraphTGraphAdapter.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/jgrapht/JGraphTGraphAdapter.java
@@ -181,5 +181,29 @@ public class JGraphTGraphAdapter<V> implements Graph<V> {
                 vertexIdentifiers.get(destination));
 
     }
+    
+    /**
+     * Divides an edge into two edges with an inserted vertex in the middle.
+     * 
+     * @param edge
+     *            Edge to be divided.
+     * @param vertex
+     *            Vertex to be inserted.
+     */
+	@Override
+	public void divideEdge(Edge<V> edge, V vertex) {		
+		removeEdge(edge);
+		addVertex(vertex);
+		addEdge(getSource(edge), vertex);
+		addEdge(vertex, getDestination(edge));
+	}
+
+	/**
+	 * @param edge
+	 *            Edge to be removed.
+	 */
+	private void removeEdge(Edge<V> edge) {
+        internalGraph.removeEdge(unpackEdge(edge));
+	}
 
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentContent.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentContent.java
@@ -1,0 +1,15 @@
+package nl.tudelft.lifetiles.graph.sequence;
+
+/**
+ * Interface for the content in a sequence segment.
+ * @author Jos
+ *
+ */
+public interface SegmentContent {
+
+	/**
+	 * @return length of the content in the segment.
+	 */
+	long length();
+	
+}

--- a/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentEmpty.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentEmpty.java
@@ -1,0 +1,30 @@
+package nl.tudelft.lifetiles.graph.sequence;
+
+
+/**
+ * Segment content with empty content.
+ * @author Jos
+ *
+ */
+public class SegmentEmpty implements SegmentContent {
+
+	private long lengthVar;
+
+	/**
+	 * Constructs a sequence segment with given string as content.
+	 * @param length
+	 *			Length of the empty content of the segment.
+	 */
+	public SegmentEmpty(long length) {
+		lengthVar = length;
+	}
+	
+	/**
+	 * @return length of the empty content of the segment.
+	 */
+	@Override
+	public long length() {
+		return lengthVar;
+	}
+
+}

--- a/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentString.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/sequence/SegmentString.java
@@ -1,0 +1,29 @@
+package nl.tudelft.lifetiles.graph.sequence;
+
+/**
+ * Segment content with as content a string.
+ * @author Jos
+ *
+ */
+public class SegmentString implements SegmentContent {
+
+	private String contentVar;
+
+	/**
+	 * Constructs a sequence segment with given string as content.
+	 * @param content
+	 *			String to be set as content of the sequence segment.
+	 */
+	public SegmentString(String content) {
+		contentVar = content;
+	}
+	
+	/**
+	 * @return length of the string content in the segment.
+	 */
+	@Override
+	public long length() {
+		return contentVar.length();
+	}
+
+}

--- a/src/main/java/nl/tudelft/lifetiles/graph/sequence/SequenceSegment.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/sequence/SequenceSegment.java
@@ -22,7 +22,7 @@ public class SequenceSegment {
     /**
      * The content of this segment.
      */
-    private String contentVar;
+    private SegmentContent contentVar;
 
     /**
      * @param sources
@@ -35,7 +35,7 @@ public class SequenceSegment {
      *            The content for this segment.
      */
     public SequenceSegment(final Set<String> sources, final long startPosition,
-            final long endPosition, final String content) {
+            final long endPosition, final SegmentContent content) {
         sourcesVar = sources;
         startVar = startPosition;
         endVar = endPosition;
@@ -78,7 +78,7 @@ public class SequenceSegment {
     /**
      * @return the content
      */
-    public final String getContent() {
+    public final SegmentContent getContent() {
         return contentVar;
     }
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/sequence/SequenceSegment.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/sequence/SequenceSegment.java
@@ -1,4 +1,4 @@
-package nl.tudelft.lifetiles.graph;
+package nl.tudelft.lifetiles.graph.sequence;
 
 import java.util.Set;
 

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -2,7 +2,7 @@ package nl.tudelft.lifetiles.graph.traverser;
 
 import nl.tudelft.lifetiles.graph.Edge;
 import nl.tudelft.lifetiles.graph.Graph;
-import nl.tudelft.lifetiles.graph.SequenceSegment;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 /**
  * Aligns sequences in a graph of sequences, by filling empty space with empty vertices.

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -1,0 +1,34 @@
+package nl.tudelft.lifetiles.graph.traverser;
+
+import nl.tudelft.lifetiles.graph.Graph;
+import nl.tudelft.lifetiles.graph.SequenceSegment;
+
+/**
+ * Aligns sequences in a graph of sequences, by filling empty space with empty vertices.
+ * @author Jos
+ */
+public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
+
+	/**
+	 * Traverse a graph and return the aligned graph.
+	 * @param graph
+	 *			The graph that is being aligned.
+	 * @return aligned graph.
+	 */
+	@Override
+	public Graph<SequenceSegment> traverseGraph(Graph<SequenceSegment> graph) {
+		return graph;
+	}
+
+	/**
+	 * Traverse a vertex in the graph and return the aligned vertex.
+	 * @param graph
+	 * @param vertex
+	 *			The vertex that is being traversed.
+	 * @return aligned vertex.
+	 */
+	@Override
+	public SequenceSegment traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
+		return vertex;
+	}
+}

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -2,6 +2,7 @@ package nl.tudelft.lifetiles.graph.traverser;
 
 import nl.tudelft.lifetiles.graph.Edge;
 import nl.tudelft.lifetiles.graph.Graph;
+import nl.tudelft.lifetiles.graph.sequence.SegmentEmpty;
 import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 /**
@@ -54,7 +55,7 @@ public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
 			destination.getSources(),
 			source.getEnd() + 1,
 			destination.getStart() - 1,
-			new String(new char[(int) source.distanceTo(destination)]).replace("\0", "_")
+			new SegmentEmpty(source.distanceTo(destination))
 		);
 	}
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -32,14 +32,13 @@ public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
 	 *			The vertex that is being traversed.
 	 * @return aligned vertex.
 	 */
-	private SequenceSegment traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
+	private void traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
 		for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {
 			SequenceSegment destination = graph.getDestination(edge);
 			if (vertex.distanceTo(destination) > 1) {
 				graph.divideEdge(edge, bridgeSequence(vertex, destination));
 			}
 		}
-		return vertex;
 	}
 	
 	/**

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -27,8 +27,7 @@ public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
 	 *			The vertex that is being traversed.
 	 * @return aligned vertex.
 	 */
-	@Override
-	public SequenceSegment traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
+	private SequenceSegment traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
 		return vertex;
 	}
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -1,5 +1,6 @@
 package nl.tudelft.lifetiles.graph.traverser;
 
+import nl.tudelft.lifetiles.graph.Edge;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.SequenceSegment;
 
@@ -17,17 +18,44 @@ public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
 	 */
 	@Override
 	public Graph<SequenceSegment> traverseGraph(Graph<SequenceSegment> graph) {
+		for (SequenceSegment source : graph.getSource()) {
+			traverseVertex(graph, source);
+		}
 		return graph;
 	}
 
 	/**
 	 * Traverse a vertex in the graph and return the aligned vertex.
 	 * @param graph
+	 *			The graph that can be modified on.
 	 * @param vertex
 	 *			The vertex that is being traversed.
 	 * @return aligned vertex.
 	 */
 	private SequenceSegment traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
+		for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {
+			SequenceSegment destination = graph.getDestination(edge);
+			if (vertex.distanceTo(destination) > 1) {
+				graph.divideEdge(edge, bridgeSequence(vertex, destination));
+			}
+		}
 		return vertex;
+	}
+	
+	/**
+	 * Creates a bridge sequence segment between a source and destination segment.
+	 * @param source
+	 *			The vertex that is the source segment.
+	 * @param destination
+	 *			The vertex that is the destination segment.
+	 * @return sequence segment between source and destination segment
+	 */
+	private SequenceSegment bridgeSequence(SequenceSegment source, SequenceSegment destination) {
+		return new SequenceSegment(
+			destination.getSources(),
+			source.getEnd() + 1,
+			destination.getStart() - 1,
+			new String(new char[(int) source.distanceTo(destination)]).replace("\0", "_")
+		);
 	}
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverser.java
@@ -31,7 +31,6 @@ public class AlignmentTraverser implements GraphTraverser<SequenceSegment> {
 	 *			The graph that can be modified on.
 	 * @param vertex
 	 *			The vertex that is being traversed.
-	 * @return aligned vertex.
 	 */
 	private void traverseVertex(Graph<SequenceSegment> graph, SequenceSegment vertex) {
 		for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/GraphTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/GraphTraverser.java
@@ -17,13 +17,4 @@ public interface GraphTraverser<V> {
 	 * @return (modified) graph.
 	 */
 	Graph<V> traverseGraph(Graph<V> graph);
-	
-	/**
-	 * Traverse a vertex in the graph.
-	 * @param graph
-	 * @param vertex
-	 *			The vertex that is being traversed.
-	 * @return (modified) vertex.
-	 */
-	V traverseVertex(Graph<V> graph, V vertex);
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/GraphTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/GraphTraverser.java
@@ -1,0 +1,29 @@
+package nl.tudelft.lifetiles.graph.traverser;
+
+import nl.tudelft.lifetiles.graph.Graph;
+
+/**
+ * Interface for a generic graph traversal on a generic graph.
+ * @author Jos
+ * @param <V>
+ *            The Class to use as vertices.
+ */
+public interface GraphTraverser<V> {
+
+	/**
+	 * Traverse a graph and return the modified graph.
+	 * @param graph
+	 *			The graph that is being traversed.
+	 * @return (modified) graph.
+	 */
+	Graph<V> traverseGraph(Graph<V> graph);
+	
+	/**
+	 * Traverse a vertex in the graph.
+	 * @param graph
+	 * @param vertex
+	 *			The vertex that is being traversed.
+	 * @return (modified) vertex.
+	 */
+	V traverseVertex(Graph<V> graph, V vertex);
+}

--- a/src/main/resources/styles/MainStyle.css
+++ b/src/main/resources/styles/MainStyle.css
@@ -5,7 +5,7 @@
     -fx-font-family: 'Open Sans Light';
     -fx-font-size: 11pt;
 
-    -fx-border-color: #CCCCCC;
+    -fx-border-color: #5B5B5B;
     -fx-border-width: 1;
     -fx-border-style: solid;
 }

--- a/src/test/java/nl/tudelft/lifetiles/graph/FactoryProducerTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/FactoryProducerTest.java
@@ -26,7 +26,7 @@ public class FactoryProducerTest {
     @Test
     public void testGetWrongParam() {
         thrown.expect(IllegalArgumentException.class);
-        GraphFactory<String> gf = fp.getFactory("libfoo");
+        fp.getFactory("libfoo");
     }
 
     @Test

--- a/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
@@ -1,6 +1,8 @@
 package nl.tudelft.lifetiles.graph;
 
 import static org.junit.Assert.assertEquals;
+import nl.tudelft.lifetiles.graph.sequence.SegmentEmpty;
+import nl.tudelft.lifetiles.graph.sequence.SegmentString;
 import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
@@ -12,9 +14,9 @@ public class SequenceSegmentTest {
 
     @Before
     public void setUp() throws Exception {
-        v1 = new SequenceSegment(null, 1, 10, null);
-        v2 = new SequenceSegment(null, 11, 20, null);
-        v3 = new SequenceSegment(null, 21, 30, null);
+        v1 = new SequenceSegment(null, 1, 10, new SegmentString("AAAAAAAAAA"));
+        v2 = new SequenceSegment(null, 11, 20, new SegmentEmpty(10));
+        v3 = new SequenceSegment(null, 21, 30, new SegmentString("AAAAAAAAAA"));
     }
     
     @Test
@@ -30,5 +32,14 @@ public class SequenceSegmentTest {
     @Test
     public void testDistanceToNegative() {
     	assertEquals(-30, v3.distanceTo(v1));
+    }
+
+    @Test
+    public void testLengthEmpty() {
+    	assertEquals(10, v2.getContent().length());
+    }
+    @Test
+    public void testLengthString() {
+    	assertEquals(10, v1.getContent().length());
     }
 }

--- a/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
@@ -1,6 +1,7 @@
 package nl.tudelft.lifetiles.graph;
 
 import static org.junit.Assert.assertEquals;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/SequenceSegmentTest.java
@@ -1,0 +1,33 @@
+package nl.tudelft.lifetiles.graph;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SequenceSegmentTest {
+
+    SequenceSegment v1, v2, v3;
+
+    @Before
+    public void setUp() throws Exception {
+        v1 = new SequenceSegment(null, 1, 10, null);
+        v2 = new SequenceSegment(null, 11, 20, null);
+        v3 = new SequenceSegment(null, 21, 30, null);
+    }
+    
+    @Test
+    public void testDistanceToAdjacent() {
+    	assertEquals(0, v1.distanceTo(v2));
+    }
+    
+    @Test
+    public void testDistanceToPositive() {
+    	assertEquals(10, v1.distanceTo(v3));
+    }
+    
+    @Test
+    public void testDistanceToNegative() {
+    	assertEquals(-30, v3.distanceTo(v1));
+    }
+}

--- a/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/EdgeAdapterTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/EdgeAdapterTest.java
@@ -6,7 +6,7 @@ import nl.tudelft.lifetiles.graph.Edge;
 import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
-import nl.tudelft.lifetiles.graph.SequenceSegment;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphAdapterTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphAdapterTest.java
@@ -9,7 +9,7 @@ import nl.tudelft.lifetiles.graph.Edge;
 import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
-import nl.tudelft.lifetiles.graph.SequenceSegment;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphAdapterTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphAdapterTest.java
@@ -121,4 +121,16 @@ public class GraphAdapterTest {
         assertEquals(v2, gr.getDestination(inc.iterator().next()));
     }
 
+    @Test
+    public void testDivideEdge() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        gr.addEdge(v1, v2);
+        Set<Edge<SequenceSegment>> inc = gr.getIncoming(v2);
+    	SequenceSegment v3 = new SequenceSegment(null, 0, 0, null);
+        gr.divideEdge(inc.iterator().next(), v3);
+        assertEquals(v3, gr.getSource(gr.getIncoming(v2).iterator().next()));
+        assertEquals(v3, gr.getDestination(gr.getOutgoing(v1).iterator().next()));
+    }
+
 }

--- a/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphFactoryImplementationTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/jgrapht/GraphFactoryImplementationTest.java
@@ -3,7 +3,7 @@ package nl.tudelft.lifetiles.graph.jgrapht;
 import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
-import nl.tudelft.lifetiles.graph.SequenceSegment;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
@@ -5,6 +5,7 @@ import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
 import nl.tudelft.lifetiles.graph.sequence.SegmentEmpty;
+import nl.tudelft.lifetiles.graph.sequence.SegmentString;
 import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
@@ -27,9 +28,9 @@ public class AlignmentTraverserTest {
     @Before
     public void setUp() throws Exception {
         gf = fp.getFactory("JGraphT");
-        v1 = new SequenceSegment(null, 1, 10, new SegmentEmpty(10));
+        v1 = new SequenceSegment(null, 1, 10, new SegmentString("AAAAAAAAAA"));
         v2 = new SequenceSegment(null, 11, 20, new SegmentEmpty(10));
-        v3 = new SequenceSegment(null, 21, 30, new SegmentEmpty(10));
+        v3 = new SequenceSegment(null, 21, 30, new SegmentString("AAAAAAAAAA"));
         gr = gf.getGraph();
     }
     

--- a/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
@@ -1,7 +1,6 @@
 package nl.tudelft.lifetiles.graph.traverser;
 
 import static org.junit.Assert.assertEquals;
-
 import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
@@ -27,9 +26,9 @@ public class AlignmentTraverserTest {
     @Before
     public void setUp() throws Exception {
         gf = fp.getFactory("JGraphT");
-        v1 = new SequenceSegment(null, 1, 10, "AAAAAAAAAA");
-        v2 = new SequenceSegment(null, 11, 20, "AAAAAAAAAA");
-        v3 = new SequenceSegment(null, 21, 30, "AAAAAAAAAA");
+        v1 = new SequenceSegment(null, 1, 10, "__________");
+        v2 = new SequenceSegment(null, 11, 20, "__________");
+        v3 = new SequenceSegment(null, 21, 30, "__________");
         gr = gf.getGraph();
     }
     
@@ -39,7 +38,7 @@ public class AlignmentTraverserTest {
         gr.addVertex(v3);
         gr.addEdge(v1, v3);
         at.traverseGraph(gr);
-        assertEquals(gr.getOutgoing(v1).iterator().next(), gr.getIncoming(v3).iterator().next());
+        assertEquals(gr.getDestination(gr.getOutgoing(v1).iterator().next()), gr.getSource(gr.getIncoming(v3).iterator().next()));
 	}
     
 	@Test

--- a/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
@@ -4,7 +4,8 @@ import static org.junit.Assert.assertEquals;
 import nl.tudelft.lifetiles.graph.FactoryProducer;
 import nl.tudelft.lifetiles.graph.Graph;
 import nl.tudelft.lifetiles.graph.GraphFactory;
-import nl.tudelft.lifetiles.graph.SequenceSegment;
+import nl.tudelft.lifetiles.graph.sequence.SegmentEmpty;
+import nl.tudelft.lifetiles.graph.sequence.SequenceSegment;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,9 +27,9 @@ public class AlignmentTraverserTest {
     @Before
     public void setUp() throws Exception {
         gf = fp.getFactory("JGraphT");
-        v1 = new SequenceSegment(null, 1, 10, "__________");
-        v2 = new SequenceSegment(null, 11, 20, "__________");
-        v3 = new SequenceSegment(null, 21, 30, "__________");
+        v1 = new SequenceSegment(null, 1, 10, new SegmentEmpty(10));
+        v2 = new SequenceSegment(null, 11, 20, new SegmentEmpty(10));
+        v3 = new SequenceSegment(null, 21, 30, new SegmentEmpty(10));
         gr = gf.getGraph();
     }
     

--- a/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/traverser/AlignmentTraverserTest.java
@@ -1,0 +1,56 @@
+package nl.tudelft.lifetiles.graph.traverser;
+
+import static org.junit.Assert.assertEquals;
+
+import nl.tudelft.lifetiles.graph.FactoryProducer;
+import nl.tudelft.lifetiles.graph.Graph;
+import nl.tudelft.lifetiles.graph.GraphFactory;
+import nl.tudelft.lifetiles.graph.SequenceSegment;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AlignmentTraverserTest {
+    GraphFactory<SequenceSegment> gf;
+    static FactoryProducer<SequenceSegment> fp;
+	static AlignmentTraverser at;
+    SequenceSegment v1, v2, v3;
+    Graph<SequenceSegment> gr;
+
+    @BeforeClass
+    public static void runOnce() {
+        fp = new FactoryProducer<SequenceSegment>();
+        at = new AlignmentTraverser();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        gf = fp.getFactory("JGraphT");
+        v1 = new SequenceSegment(null, 1, 10, "AAAAAAAAAA");
+        v2 = new SequenceSegment(null, 11, 20, "AAAAAAAAAA");
+        v3 = new SequenceSegment(null, 21, 30, "AAAAAAAAAA");
+        gr = gf.getGraph();
+    }
+    
+	@Test
+	public void testTraverseGapGraph() {
+        gr.addVertex(v1);
+        gr.addVertex(v3);
+        gr.addEdge(v1, v3);
+        at.traverseGraph(gr);
+        assertEquals(gr.getOutgoing(v1).iterator().next(), gr.getIncoming(v3).iterator().next());
+	}
+    
+	@Test
+	public void testTraverseBridgeGraph() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        gr.addVertex(v3);
+        gr.addEdge(v1, v2);
+        gr.addEdge(v2, v3);
+        at.traverseGraph(gr);
+        assertEquals(3, at.traverseGraph(gr).getAllVertices().size());
+	}
+
+}


### PR DESCRIPTION
Implemented an AlignmentTraverser which traverser a DNA sequence graph and inserts empty sequence segment. Added some extra functionality to sequence segment and graphAdaptar Also some small other changes:
- changes stylesheet, window border visibility
- fixed warning in FactoryProducerTest
