### PR TITLE
Fixed #71 Sequence Parser Bug 

### DIFF
--- a/src/main/java/nl/tudelft/lifetiles/graph/models/DefaultGraphParser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/models/DefaultGraphParser.java
@@ -54,7 +54,7 @@ public class DefaultGraphParser implements GraphParser {
             throw new IllegalArgumentException();
         }
         String[] desc = descriptor.split("\\|");
-        String[] sources = desc[2].split(",");
+        String[] sources = desc[1].split(",");
         Set<Sequence> currentSequences = new HashSet<>();
         for (String sequencename : sources) {
             sequencename = sequencename.trim();

--- a/src/test/java/nl/tudelft/lifetiles/graph/models/sequence/SequenceGeneratorTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/models/sequence/SequenceGeneratorTest.java
@@ -1,0 +1,29 @@
+package nl.tudelft.lifetiles.graph.models.sequence;
+
+import static org.junit.Assert.assertEquals;
+import nl.tudelft.lifetiles.graph.models.DefaultGraphParser;
+import nl.tudelft.lifetiles.graph.models.FactoryProducer;
+import nl.tudelft.lifetiles.graph.models.Graph;
+import nl.tudelft.lifetiles.graph.models.GraphFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SequenceGeneratorTest {
+    SequenceGenerator sg;
+
+    @Before
+    public void setUp() {
+        FactoryProducer<SequenceSegment> fp = new FactoryProducer<SequenceSegment>();
+        GraphFactory<SequenceSegment> gf = fp.getFactory("JGraphT");
+        DefaultGraphParser parser = new DefaultGraphParser();
+        Graph<SequenceSegment> gr = parser.parseFile(
+                "data/test_set/simple_graph", gf);
+        sg = new SequenceGenerator(gr);
+    }
+
+    @Test
+    public void generateSequencesTest() {
+        assertEquals(2, sg.generateSequences().size());
+    }
+}


### PR DESCRIPTION
Parser returns wrong data, not sequences but segment coordinates, must be looked at. Add test and solve.
