### PR TITLE
Removed the faulty IllegalArgumentException when filtering sequences.

### DIFF
--- a/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
+++ b/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
@@ -93,7 +93,7 @@ public class SequenceController extends Controller {
      *            shout that the seqeunces have been filtered
      */
     private void setVisible(final Set<Sequence> visible, final boolean shout) {
-        if (!visible.containsAll(sequences.values())) {
+        if (!sequences.values().containsAll(visible)) {
             throw new IllegalArgumentException(
                     "Attempted to set a non-existant sequence to visible");
         }


### PR DESCRIPTION
When filtering in the sequence view, an `IllegalArgumentException` got thrown, this is not the case anymore.
