### PR TITLE
Rewritten the unification algorithm to use bfs.

### DIFF
--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverser.java
@@ -1,6 +1,9 @@
 package nl.tudelft.lifetiles.graph.traverser;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
 
 import nl.tudelft.lifetiles.core.util.Timer;
 import nl.tudelft.lifetiles.graph.model.Edge;
@@ -19,7 +22,7 @@ public class UnifiedPositionTraverser {
     /**
      * Graph which is being traversed.
      */
-    private Graph<SequenceSegment> graphVar;
+    private Graph<SequenceSegment> graph;
 
     /**
      * Traverses the graph, calculates the unified position. Unified positions
@@ -31,9 +34,9 @@ public class UnifiedPositionTraverser {
      */
     public final Graph<SequenceSegment> unifyGraph(
             final Graph<SequenceSegment> graph) {
-        this.graphVar = graph;
+        this.graph = graph;
         unifyGraph();
-        return graphVar;
+        return graph;
     }
 
     /**
@@ -43,34 +46,49 @@ public class UnifiedPositionTraverser {
     private void unifyGraph() {
         Timer timer = Timer.getAndStart();
 
-        for (SequenceSegment vertex : graphVar.getSources()) {
+        // a stack for depth-first
+        Queue<SequenceSegment> queue = new ArrayDeque<>();
+        Map<SequenceSegment, Integer> waiting = new HashMap<>();
+
+        for (SequenceSegment vertex : graph.getSources()) {
             vertex.setUnifiedStart(1);
             vertex.setUnifiedEnd(1 + vertex.getContent().getLength());
-            unifyVertex(vertex);
+            queue.add(vertex);
+        }
+
+        while (!queue.isEmpty()) {
+            SequenceSegment vertex = queue.poll();
+
+            // Only continue traversal once all incoming paths to this vertex
+            // have been traversed.
+            final int inLinks = graph.getIncoming(vertex).size();
+            if (waiting.containsKey(vertex)) {
+                int newVal = waiting.get(vertex) - 1;
+                if (newVal < 1) {
+                    // not waiting for the vertex anymore, continue traversal
+                    waiting.remove(vertex);
+                } else {
+                    waiting.put(vertex, newVal);
+                    continue;
+                }
+            } else if (inLinks > 1) {
+                waiting.put(vertex, inLinks - 1);
+                continue;
+            }
+
+            final long position = vertex.getUnifiedStart()
+                    + vertex.getContent().getLength();
+            for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {
+                SequenceSegment next = graph.getDestination(edge);
+                if (next.getUnifiedStart() < position) {
+                    next.setUnifiedStart(position);
+                    next.setUnifiedEnd(position + next.getContent().getLength());
+                }
+                queue.add(next);
+            }
         }
 
         timer.stopAndLog("Graph unification");
-    }
-
-    /**
-     * Traverses the vertex, calculates its unified position.
-     *
-     * @param vertex
-     *            Vertex to be traversed.
-     */
-    private void unifyVertex(final SequenceSegment vertex) {
-        long vertexPosition = vertex.getUnifiedStart()
-                + vertex.getContent().getLength();
-        for (Edge<SequenceSegment> edge : new ArrayList<Edge<SequenceSegment>>(
-                graphVar.getOutgoing(vertex))) {
-            SequenceSegment destination = graphVar.getDestination(edge);
-            if (destination.getUnifiedStart() < vertexPosition) {
-                destination.setUnifiedStart(vertexPosition);
-                destination.setUnifiedEnd(vertexPosition
-                        + destination.getContent().getLength());
-                unifyVertex(destination);
-            }
-        }
     }
 
 }

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverser.java
@@ -46,7 +46,7 @@ public class UnifiedPositionTraverser {
     private void unifyGraph() {
         Timer timer = Timer.getAndStart();
 
-        // a stack for depth-first
+        // a queue for breadth-first
         Queue<SequenceSegment> queue = new ArrayDeque<>();
         Map<SequenceSegment, Integer> waiting = new HashMap<>();
 

--- a/src/test/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverserTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/traverser/UnifiedPositionTraverserTest.java
@@ -21,7 +21,7 @@ public class UnifiedPositionTraverserTest {
     GraphFactory<SequenceSegment> gf;
     static UnifiedPositionTraverser upt;
     static Set<Sequence> s1;
-    SequenceSegment v1, v2;
+    SequenceSegment v1, v2, v3;
     Graph<SequenceSegment> gr;
 
     @BeforeClass
@@ -40,6 +40,8 @@ public class UnifiedPositionTraverserTest {
         gf = FactoryProducer.getFactory("JGraphT");
         v1 = new SequenceSegment(s1, 1, 11, new SegmentString("AAAAAAAAAA"));
         v2 = new SequenceSegment(s1, 21, 31, new SegmentString("AAAAAAAAAA"));
+        v3 = new SequenceSegment(s1, 11, 21, new SegmentString("AAAAAAAAAA"));
+
         gr = gf.getGraph();
         gr.addVertex(v1);
         gr.addVertex(v2);
@@ -53,6 +55,17 @@ public class UnifiedPositionTraverserTest {
         assertEquals(11, v1.getUnifiedEnd());
         assertEquals(11, v2.getUnifiedStart());
         assertEquals(21, v2.getUnifiedEnd());
+    }
+
+    public void traverseOutOfOrderTest() {
+        gr.addVertex(v3);
+        gr.addEdge(v1, v3);
+        gr.addEdge(v3, v2);
+        upt.unifyGraph(gr);
+        assertEquals(11, v3.getUnifiedStart());
+        assertEquals(21, v3.getUnifiedEnd());
+        assertEquals(21, v2.getUnifiedStart());
+        assertEquals(31, v2.getUnifiedEnd());
     }
 
 }


### PR DESCRIPTION
Can now load 100 sequences in under a second when mutations and empty segments are turned off. The trick was to adjust the algorithm to use breadth-first-search.

Deadline: 23:59 01-06-2015
