### PR TITLE
Reference position traverser optimization/refactor

### DIFF
--- a/src/main/java/nl/tudelft/lifetiles/core/util/IterUtils.java
+++ b/src/main/java/nl/tudelft/lifetiles/core/util/IterUtils.java
@@ -1,0 +1,32 @@
+package nl.tudelft.lifetiles.core.util;
+
+import java.util.Iterator;
+
+/**
+ * Utilities for iterators and iterables.
+ *
+ * @author Joren Hammudoglu
+ */
+public final class IterUtils {
+
+    /**
+     * Uninstantiable.
+     */
+    private IterUtils() {
+        // noop
+    }
+
+    /**
+     * Create an {@link Iterable} from an {@link Iterator}.
+     *
+     * @param iterator
+     *            the iterator
+     * @param <T>
+     *            the type
+     * @return the iterable
+     */
+    public static <T> Iterable<T> toIterable(final Iterator<T> iterator) {
+        return () -> iterator;
+    }
+
+}

--- a/src/main/java/nl/tudelft/lifetiles/core/util/IteratorUtils.java
+++ b/src/main/java/nl/tudelft/lifetiles/core/util/IteratorUtils.java
@@ -7,12 +7,12 @@ import java.util.Iterator;
  *
  * @author Joren Hammudoglu
  */
-public final class IterUtils {
+public final class IteratorUtils {
 
     /**
      * Uninstantiable.
      */
-    private IterUtils() {
+    private IteratorUtils() {
         // noop
     }
 

--- a/src/main/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIterator.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIterator.java
@@ -1,0 +1,164 @@
+package nl.tudelft.lifetiles.graph.model;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * Iterate the graph from source to sink using true vertical
+ * breadth-first search.
+ *
+ * @author Joren Hammudoglu
+ *
+ * @param <V>
+ *            the vertex type
+ */
+public class BreadthFirstIterator<V> implements Iterator<V> {
+
+    /**
+     * The graph to iterate over.
+     */
+    private final Graph<V> graph;
+
+    /**
+     * The queued vertices.
+     */
+    private final Queue<V> queue;
+
+    /**
+     * The waiting vertices with their remaining count.
+     */
+    private final Map<V, Integer> waiting;
+
+    /**
+     * Whether it should iterate backwards.
+     */
+    private boolean reverse;
+
+    /**
+     * Create a new iterator.
+     *
+     * @param graph
+     *            the graph to iterate over.
+     */
+    public BreadthFirstIterator(final Graph<V> graph) {
+        this(graph, false);
+    }
+
+    /**
+     * Create a new iterator.
+     *
+     * @param graph
+     *            the graph to iterate over.
+     * @param reverse
+     *            whether it should iterate backwards
+     */
+    public BreadthFirstIterator(final Graph<V> graph, final boolean reverse) {
+        this.graph = graph;
+        this.queue = new LinkedList<>();
+        this.waiting = new HashMap<>();
+        this.reverse = reverse;
+
+        if (reverse) {
+            initializeBackwards();
+        } else {
+            initializeForwards();
+        }
+    }
+
+    /**
+     * Initialize for forwards iteration.
+     */
+    private void initializeForwards() {
+        for (V source : graph.getSources()) {
+            queue.add(source);
+        }
+    }
+
+    /**
+     * Initialize for backwards iteration.
+     */
+    private void initializeBackwards() {
+        for (V sink : graph.getSinks()) {
+            queue.add(sink);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final boolean hasNext() {
+        return !queue.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final V next() {
+        V vertex = queue.poll();
+
+        if (vertex == null) {
+            return null;
+        }
+
+        Set<Edge<V>> outgoingVertices;
+        if (reverse) {
+            outgoingVertices = graph.getIncoming(vertex);
+        } else {
+            outgoingVertices = graph.getOutgoing(vertex);
+        }
+
+        if (waitForIt(vertex)) {
+            return next();
+        }
+
+        for (Edge<V> edge : outgoingVertices) {
+            V destination;
+            if (reverse) {
+                destination = graph.getSource(edge);
+            } else {
+                destination = graph.getDestination(edge);
+            }
+            queue.add(destination);
+        }
+
+        return vertex;
+    }
+
+    /**
+     * Check if the iterator has to wait for a vertex.
+     *
+     * @param vertex
+     *            the vertex, aka "it"
+     * @return whether to wait
+     */
+    private boolean waitForIt(final V vertex) {
+        int inLinks;
+        if (reverse) {
+            inLinks = graph.getOutgoing(vertex).size();
+        } else {
+            inLinks = graph.getIncoming(vertex).size();
+        }
+
+        if (waiting.containsKey(vertex)) {
+            int newVal = waiting.get(vertex) - 1;
+            if (newVal < 1) {
+                // not waiting for the vertex anymore, continue traversal
+                waiting.remove(vertex);
+            } else {
+                waiting.put(vertex, newVal);
+                return true;
+            }
+        } else if (inLinks > 1) {
+            waiting.put(vertex, inLinks - 1);
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIterator.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIterator.java
@@ -113,7 +113,7 @@ public class BreadthFirstIterator<V> implements Iterator<V> {
             outgoingVertices = graph.getOutgoing(vertex);
         }
 
-        if (waitForIt(vertex)) {
+        if (waitForVertex(vertex)) {
             return next();
         }
 
@@ -134,10 +134,10 @@ public class BreadthFirstIterator<V> implements Iterator<V> {
      * Check if the iterator has to wait for a vertex.
      *
      * @param vertex
-     *            the vertex, aka "it"
+     *            the vertex to wait for
      * @return whether to wait
      */
-    private boolean waitForIt(final V vertex) {
+    private boolean waitForVertex(final V vertex) {
         int inLinks;
         if (reverse) {
             inLinks = graph.getOutgoing(vertex).size();

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/ReferencePositionTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/ReferencePositionTraverser.java
@@ -2,7 +2,7 @@ package nl.tudelft.lifetiles.graph.traverser;
 
 import java.util.Iterator;
 
-import nl.tudelft.lifetiles.core.util.IterUtils;
+import nl.tudelft.lifetiles.core.util.IteratorUtils;
 import nl.tudelft.lifetiles.core.util.Timer;
 import nl.tudelft.lifetiles.graph.model.BreadthFirstIterator;
 import nl.tudelft.lifetiles.graph.model.Edge;
@@ -67,7 +67,7 @@ public class ReferencePositionTraverser {
 
         Iterator<SequenceSegment> iterator = new BreadthFirstIterator<>(graph);
 
-        for (SequenceSegment vertex : IterUtils.toIterable(iterator)) {
+        for (SequenceSegment vertex : IteratorUtils.toIterable(iterator)) {
             long position = vertex.getReferenceStart();
             if (vertex.getSources().contains(reference)
                     && !vertex.getContent().isEmpty()) {
@@ -100,7 +100,7 @@ public class ReferencePositionTraverser {
 
         Iterator<SequenceSegment> iterator = new BreadthFirstIterator<>(graph,
                 true);
-        for (SequenceSegment vertex : IterUtils.toIterable(iterator)) {
+        for (SequenceSegment vertex : IteratorUtils.toIterable(iterator)) {
             long position = vertex.getReferenceEnd();
 
             if (vertex.getSources().contains(reference)

--- a/src/main/java/nl/tudelft/lifetiles/graph/traverser/ReferencePositionTraverser.java
+++ b/src/main/java/nl/tudelft/lifetiles/graph/traverser/ReferencePositionTraverser.java
@@ -1,9 +1,13 @@
 package nl.tudelft.lifetiles.graph.traverser;
 
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+
 import nl.tudelft.lifetiles.core.util.Timer;
 import nl.tudelft.lifetiles.graph.model.Edge;
 import nl.tudelft.lifetiles.graph.model.Graph;
-import nl.tudelft.lifetiles.sequence.model.SegmentString;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
@@ -12,6 +16,7 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
  * the reference sequence.
  *
  * @author Jos
+ * @author Joren Hammudoglu
  *
  */
 public class ReferencePositionTraverser {
@@ -55,9 +60,49 @@ public class ReferencePositionTraverser {
      *            Graph to be traversed.
      */
     private void referenceMapGraphForward(final Graph<SequenceSegment> graph) {
+        // a queue for breadth-first
+        Queue<SequenceSegment> queue = new ArrayDeque<>();
+        Map<SequenceSegment, Integer> waiting = new HashMap<>();
+
+        // initialize the stack
         for (SequenceSegment source : graph.getSources()) {
             source.setReferenceStart(1);
-            referenceMapVertexForward(source, graph);
+            queue.add(source);
+        }
+
+        while (!queue.isEmpty()) {
+            SequenceSegment vertex = queue.poll();
+            long position = vertex.getReferenceStart();
+
+            // Only continue traversal once all incoming paths to this vertex
+            // have been traversed.
+            final int inLinks = graph.getIncoming(vertex).size();
+            if (waiting.containsKey(vertex)) {
+                int newVal = waiting.get(vertex) - 1;
+                if (newVal < 1) {
+                    // not waiting for the vertex anymore, continue traversal
+                    waiting.remove(vertex);
+                } else {
+                    waiting.put(vertex, newVal);
+                    continue;
+                }
+            } else if (inLinks > 1) {
+                waiting.put(vertex, inLinks - 1);
+                continue;
+            }
+
+            if (vertex.getSources().contains(reference)
+                    && !vertex.getContent().isEmpty()) {
+                position += vertex.getContent().getLength();
+            }
+
+            for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {
+                SequenceSegment destination = graph.getDestination(edge);
+                if (destination.getReferenceStart() < position) {
+                    destination.setReferenceStart(position);
+                }
+                queue.add(destination);
+            }
         }
     }
 
@@ -68,6 +113,11 @@ public class ReferencePositionTraverser {
      *            Graph to be traversed.
      */
     private void referenceMapGraphBackward(final Graph<SequenceSegment> graph) {
+        // a queue for breadth-first
+        Queue<SequenceSegment> queue = new ArrayDeque<>();
+        Map<SequenceSegment, Integer> waiting = new HashMap<>();
+
+        // initialize the stack
         for (SequenceSegment sink : graph.getSinks()) {
             if (sink.getSources().contains(reference)) {
                 sink.setReferenceEnd(sink.getReferenceStart()
@@ -75,56 +125,40 @@ public class ReferencePositionTraverser {
             } else {
                 sink.setReferenceEnd(sink.getReferenceStart() - 1);
             }
-            referenceMapVertexBackward(sink, graph);
+            queue.add(sink);
         }
-    }
 
-    /**
-     * Traverses a vertex forward to generate its reference start position.
-     *
-     * @param vertex
-     *            Vertex to be traversed, calculate reference start position.
-     * @param graph
-     *            Graph to be traversed.
-     */
-    private void referenceMapVertexForward(final SequenceSegment vertex,
-            final Graph<SequenceSegment> graph) {
-        long position = vertex.getReferenceStart();
+        while (!queue.isEmpty()) {
+            SequenceSegment vertex = queue.poll();
+            long position = vertex.getReferenceEnd();
 
-        if (vertex.getSources().contains(reference)
-                && vertex.getContent() instanceof SegmentString) {
-            position += vertex.getContent().getLength();
-        }
-        for (Edge<SequenceSegment> edge : graph.getOutgoing(vertex)) {
-            SequenceSegment destination = graph.getDestination(edge);
-            if (destination.getReferenceStart() < position) {
-                destination.setReferenceStart(position);
-                referenceMapVertexForward(destination, graph);
+            // Only continue traversal once all incoming paths to this vertex
+            // have been traversed.
+            final int inLinks = graph.getIncoming(vertex).size();
+            if (waiting.containsKey(vertex)) {
+                int newVal = waiting.get(vertex) - 1;
+                if (newVal < 1) {
+                    // not waiting for the vertex anymore, continue traversal
+                    waiting.remove(vertex);
+                } else {
+                    waiting.put(vertex, newVal);
+                    continue;
+                }
+            } else if (inLinks > 1) {
+                waiting.put(vertex, inLinks - 1);
+                continue;
             }
-        }
-    }
 
-    /**
-     * Traverses a vertex backward to generate its reference end position.
-     *
-     * @param vertex
-     *            Vertex to be traversed, calculate reference end position.
-     * @param graph
-     *            Graph to be traversed.
-     */
-    private void referenceMapVertexBackward(final SequenceSegment vertex,
-            final Graph<SequenceSegment> graph) {
-        long position = vertex.getReferenceEnd();
-
-        if (vertex.getSources().contains(reference)
-                && vertex.getContent() instanceof SegmentString) {
-            position -= vertex.getContent().getLength();
-        }
-        for (Edge<SequenceSegment> edge : graph.getIncoming(vertex)) {
-            SequenceSegment source = graph.getSource(edge);
-            if (source.getReferenceEnd() > position) {
-                source.setReferenceEnd(position);
-                referenceMapVertexBackward(source, graph);
+            if (vertex.getSources().contains(reference)
+                    && !vertex.getContent().isEmpty()) {
+                position -= vertex.getContent().getLength();
+            }
+            for (Edge<SequenceSegment> edge : graph.getIncoming(vertex)) {
+                SequenceSegment source = graph.getSource(edge);
+                if (source.getReferenceEnd() > position) {
+                    source.setReferenceEnd(position);
+                }
+                queue.add(source);
             }
         }
     }

--- a/src/main/resources/settings/lifetiles.conf
+++ b/src/main/resources/settings/lifetiles.conf
@@ -1,3 +1,3 @@
 #LifeTiles properties file
 empty_segments = false
-mutations = false
+mutations = true

--- a/src/main/resources/settings/lifetiles.conf
+++ b/src/main/resources/settings/lifetiles.conf
@@ -1,3 +1,3 @@
 #LifeTiles properties file
-empty_segments = false;
-mutations = false;
+empty_segments = false
+mutations = false

--- a/src/test/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIteratorTest.java
+++ b/src/test/java/nl/tudelft/lifetiles/graph/model/BreadthFirstIteratorTest.java
@@ -1,0 +1,97 @@
+package nl.tudelft.lifetiles.graph.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import nl.tudelft.lifetiles.graph.traverser.UnifiedPositionTraverser;
+import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
+import nl.tudelft.lifetiles.sequence.model.SegmentString;
+import nl.tudelft.lifetiles.sequence.model.Sequence;
+import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BreadthFirstIteratorTest {
+
+    Graph<SequenceSegment> graph;
+    HashSet<Sequence> s1, s2, s3;
+    List<SequenceSegment> vertices;
+
+    @Before
+    public void setUp() throws Exception {
+        GraphFactory<SequenceSegment> fact = FactoryProducer.getFactory();
+        this.graph = fact.getGraph();
+
+        Sequence ss1 = new DefaultSequence("reference");
+        Sequence ss2 = new DefaultSequence("mutation");
+
+        s1 = new HashSet<Sequence>();
+        s1.add(ss1);
+        s1.add(ss2);
+
+        s2 = new HashSet<Sequence>();
+        s2.add(ss1);
+
+        s3 = new HashSet<Sequence>();
+        s3.add(ss2);
+
+        SegmentString content = new SegmentString("AC");
+
+        vertices = Arrays.asList(
+                new SequenceSegment(s1, 1, 11, content),
+                new SequenceSegment(s2, 11, 21, content),
+                new SequenceSegment(s2, 21, 31, content),
+                new SequenceSegment(s2, 31, 41, content),
+                new SequenceSegment(s3, 11, 41, content),
+                new SequenceSegment(s2, 41, 51, content));
+
+        vertices.forEach(graph::addVertex);
+
+        graph.addEdge(vertices.get(0), vertices.get(1));
+        graph.addEdge(vertices.get(1), vertices.get(2));
+        graph.addEdge(vertices.get(2), vertices.get(3));
+        graph.addEdge(vertices.get(3), vertices.get(5));
+        graph.addEdge(vertices.get(0), vertices.get(4));
+        graph.addEdge(vertices.get(4), vertices.get(5));
+
+        UnifiedPositionTraverser traverser = new UnifiedPositionTraverser();
+        traverser.unifyGraph(graph);
+    }
+
+    @Test
+    public void testHasNext() {
+        BreadthFirstIterator<SequenceSegment> it = new BreadthFirstIterator<>(
+                graph);
+        assertTrue(it.hasNext());
+    }
+
+    @Test
+    public void testOrder() {
+        BreadthFirstIterator<SequenceSegment> it = new BreadthFirstIterator<>(
+                graph);
+        List<SequenceSegment> expected = Arrays.asList(
+                vertices.get(0), vertices.get(1), vertices.get(4),
+                vertices.get(2), vertices.get(3), vertices.get(5));
+        List<SequenceSegment> actual = Arrays.asList(it.next(), it.next(),
+                it.next(), it.next(), it.next(), it.next());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReversedOrder() {
+        BreadthFirstIterator<SequenceSegment> it = new BreadthFirstIterator<>(
+                graph, true);
+        List<SequenceSegment> expected = Arrays.asList(
+                vertices.get(5), vertices.get(4), vertices.get(3),
+                vertices.get(2), vertices.get(1), vertices.get(0));
+        List<SequenceSegment> actual = Arrays.asList(it.next(), it.next(),
+                it.next(), it.next(), it.next(), it.next());
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
Runs in ~1s for the 100 strains data set.

Introduced `BreadthFirstIterator` which iterates the graph using "true" breadth-first search.

Will be merged at _23:59 03-06-2015_
