### PR TITLE
Sequence meta data parsing and displaying

### DIFF
--- a/lifetiles-core/src/main/java/nl/tudelft/lifetiles/core/controller/MenuController.java
+++ b/lifetiles-core/src/main/java/nl/tudelft/lifetiles/core/controller/MenuController.java
@@ -39,11 +39,14 @@ public class MenuController extends AbstractController {
      * Extension of the edge file.
      */
     private static final String EDGE_EXTENSION = ".edge.graph";
-
     /**
      * Extension of the tree file.
      */
     private static final String TREE_EXTENSION = ".nwk";
+    /**
+     * Extension of the sequence meta data file.
+     */
+    private static final String META_EXTENSION = ".meta";
 
     /**
      * The initial x-coordinate of the window.
@@ -113,6 +116,7 @@ public class MenuController extends AbstractController {
         loadGraph(directory);
         loadTree(directory);
         loadAnnotations(directory);
+        loadMetaData(directory);
     }
 
     /**
@@ -130,6 +134,22 @@ public class MenuController extends AbstractController {
         File edgeFile = FileUtils.getSingleFileByExtension(directory,
                 EDGE_EXTENSION);
         shout(Message.OPENED, "graph", nodeFile, edgeFile);
+    }
+
+    /**
+     * Loads the sequence meta-data file in the specified directory.
+     *
+     * @param directory
+     *            The directory in which to locate the files.
+     * @throws IOException
+     *             When the directory does not contain exactly one graph file
+     *             and one node file.
+     */
+    private void loadMetaData(final File directory) throws IOException {
+        File metaDataFile = loadOrWarn(directory, META_EXTENSION);
+        if (metaDataFile != null) {
+            shout(Message.OPENED, "meta", metaDataFile);
+        }
     }
 
     /**

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
@@ -1,9 +1,12 @@
 package nl.tudelft.lifetiles.sequence.controller;
 
+import java.io.File;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
 
@@ -15,9 +18,14 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import nl.tudelft.lifetiles.core.controller.AbstractController;
+import nl.tudelft.lifetiles.core.util.Logging;
 import nl.tudelft.lifetiles.core.util.Message;
+import nl.tudelft.lifetiles.notification.controller.NotificationController;
+import nl.tudelft.lifetiles.notification.model.AbstractNotification;
+import nl.tudelft.lifetiles.notification.model.NotificationFactory;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceEntry;
+import nl.tudelft.lifetiles.sequence.model.SequenceMetaParser;
 
 /**
  * The controller of the data view.
@@ -125,6 +133,46 @@ public final class SequenceController extends AbstractController {
             updateVisible(visibleSet);
             shout(Message.FILTERED, "", visibleSet);
         });
+
+        listen(Message.OPENED,
+                (sender, subject, args) -> {
+                    if (!subject.equals("meta")) {
+                        return;
+                    }
+                    assert args[0] instanceof File;
+
+                    SequenceMetaParser parser = new SequenceMetaParser();
+                    try {
+                        parser.parse((File) args[0]);
+                        addMetaData(parser);
+                    } catch (Exception exception) {
+                        Logging.exception(exception);
+                        AbstractNotification notification = new NotificationFactory()
+                                .getNotification(exception);
+                        shout(NotificationController.NOTIFY, "", notification);
+                    }
+                });
+    }
+
+    /**
+     * Add the meta data to the appropriate sequence entries.
+     *
+     * @param parser
+     *            the parser to retrieve the data from
+     */
+    private void addMetaData(final SequenceMetaParser parser) {
+        assert parser.isParsed();
+
+        for (Entry<String, Map<String, String>> sequenceMeta : parser.getData()
+                .entrySet()) {
+            String identifier = sequenceMeta.getKey();
+            if (sequenceEntries.containsKey(identifier)) {
+                SequenceEntry sequenceEntry = sequenceEntries.get(identifier);
+                sequenceEntry.setMetaData(sequenceMeta.getValue());
+            }
+        }
+
+        addMetaColumns(parser.getColumns());
     }
 
     /**
@@ -162,6 +210,22 @@ public final class SequenceController extends AbstractController {
         referenceColumn.setCellFactory(CheckBoxTableCell
                 .forTableColumn(referenceColumn));
         referenceColumn.setEditable(true);
+    }
+
+    /**
+     * Add the meta data columns to the table.
+     *
+     * @param columns
+     *            the names of the columns
+     */
+    private void addMetaColumns(final List<String> columns) {
+        for (String columnName : columns) {
+            TableColumn<SequenceEntry, String> column = new TableColumn<>(
+                    columnName);
+            column.setCellValueFactory(entry -> entry.getValue().metaProperty(
+                    columnName));
+            sequenceTable.getColumns().add(column);
+        }
     }
 
     /**

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
@@ -144,7 +144,7 @@ public final class SequenceController extends AbstractController {
                     SequenceMetaParser parser = new SequenceMetaParser();
                     try {
                         parser.parse((File) args[0]);
-                        addMetaData(parser);
+                        addMetaData(parser.getColumns(), parser.getData());
                     } catch (Exception exception) {
                         Logging.exception(exception);
                         AbstractNotification notification = new NotificationFactory()
@@ -157,14 +157,14 @@ public final class SequenceController extends AbstractController {
     /**
      * Add the meta data to the appropriate sequence entries.
      *
-     * @param parser
-     *            the parser to retrieve the data from
+     * @param columns
+     *            The column names
+     * @param data
+     *            The actual data
      */
-    private void addMetaData(final SequenceMetaParser parser) {
-        assert parser.isParsed();
-
-        for (Entry<String, Map<String, String>> sequenceMeta : parser.getData()
-                .entrySet()) {
+    private void addMetaData(final List<String> columns,
+            final Map<String, Map<String, String>> data) {
+        for (Entry<String, Map<String, String>> sequenceMeta : data.entrySet()) {
             String identifier = sequenceMeta.getKey();
             if (sequenceEntries.containsKey(identifier)) {
                 SequenceEntry sequenceEntry = sequenceEntries.get(identifier);
@@ -172,7 +172,7 @@ public final class SequenceController extends AbstractController {
             }
         }
 
-        addMetaColumns(parser.getColumns());
+        addMetaColumns(columns);
     }
 
     /**

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceEntry.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceEntry.java
@@ -1,5 +1,9 @@
 package nl.tudelft.lifetiles.sequence.model;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -24,6 +28,10 @@ public final class SequenceEntry {
      * The reference property.
      */
     private final Property<Boolean> reference = new SimpleBooleanProperty();
+    /**
+     * The meta data.
+     */
+    private final Map<String, Property<String>> metaData = new HashMap<>();
 
     /**
      * Create a new sequence entry.
@@ -41,6 +49,7 @@ public final class SequenceEntry {
         visibleProperty().setValue(visible);
         referenceProperty().setValue(reference);
     }
+
     /**
      * Get the identifier.
      *
@@ -107,6 +116,44 @@ public final class SequenceEntry {
      */
     public Property<Boolean> referenceProperty() {
         return reference;
+    }
+
+    /**
+     * Set the meta data.
+     *
+     * @param metaData
+     *            the meta data
+     */
+    public void setMetaData(final Map<String, String> metaData) {
+        for (Entry<String, String> metaValue : metaData.entrySet()) {
+            Property<String> value = new SimpleStringProperty(
+                    metaValue.getValue());
+            this.metaData.put(metaValue.getKey(), value);
+        }
+    }
+
+    /**
+     * Get the meta data for a key.
+     *
+     * @param key
+     *            the key
+     * @return the value
+     */
+    public String getMeta(final String key) {
+        assert metaData.containsKey(key);
+        return metaProperty(key).getValue();
+    }
+
+    /**
+     * Get the meta data property.
+     *
+     * @param key
+     *            the key
+     * @return the property
+     */
+    public Property<String> metaProperty(final String key) {
+        assert metaData.containsKey(key);
+        return metaData.get(key);
     }
 
     /**

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceMetaParser.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceMetaParser.java
@@ -1,0 +1,139 @@
+package nl.tudelft.lifetiles.sequence.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import nl.tudelft.lifetiles.core.util.IteratorUtils;
+
+/**
+ * The parser for the sequence meta data.
+ *
+ * @author Joren Hammudoglu
+ *
+ */
+public final class SequenceMetaParser {
+
+    /**
+     * The name of the sequence ID column.
+     */
+    private static final String ID_COLUMN = "##ID";
+
+    /**
+     * The column names, excluding the <code>##ID</code> column.
+     */
+    private List<String> columns;
+
+    /**
+     * The parsed data.
+     */
+    private Map<String, Map<String, String>> data;
+
+    /**
+     * Parse the data.
+     *
+     * @param file
+     *            the file to parse
+     * @throws IOException
+     *             when the file was not found
+     */
+    public void parse(final File file) throws IOException {
+        Iterator<String> lineStream = Files.lines(file.toPath()).iterator();
+
+        String header = lineStream.next();
+        parseHeader(header);
+
+        data = new HashMap<>();
+        for (String line : IteratorUtils.toIterable(lineStream)) {
+            Entry<String, Map<String, String>> parsed = parseLine(line);
+            data.put(parsed.getKey(), parsed.getValue());
+        }
+    }
+
+    /**
+     * Get the column names.
+     *
+     * @return a list of column names.
+     */
+    public List<String> getColumns() {
+        maybeThrowNotParsed();
+        return columns;
+    }
+
+    /**
+     * Ge the parsed data.
+     *
+     * @return the data
+     */
+    public Map<String, Map<String, String>> getData() {
+        maybeThrowNotParsed();
+        return data;
+    }
+
+    /**
+     * @return true iff the data is parsed, else false.
+     */
+    public boolean isParsed() {
+        return data != null;
+    }
+
+    /**
+     * Throw a {@link IllegalStateException} when the data is not parsed yet.
+     */
+    private void maybeThrowNotParsed() {
+        if (!isParsed()) {
+            throw new IllegalStateException("Data not parsed.");
+        }
+    }
+
+    /**
+     * Parse the header line into column names.
+     *
+     * @param headerLine
+     *            the first line of the file
+     * @throws IOException
+     *             when the header cannot be parsed
+     */
+    private void parseHeader(final String headerLine) throws IOException {
+        List<String> allColumns = Arrays.asList(headerLine.split("\t"));
+        String firstColumn = allColumns.get(0);
+        if (!firstColumn.equals(ID_COLUMN)) {
+            throw new IOException("Invalid column header :" + firstColumn);
+        }
+
+        columns = allColumns.subList(1, allColumns.size());
+    }
+
+    /**
+     * Parse a single line.
+     *
+     * @param line
+     *            the line.
+     * @return an entry of identifier and a value map of columns to values.
+     */
+    private Entry<String, Map<String, String>> parseLine(final String line) {
+        assert columns != null;
+
+        Map<String, String> result = new HashMap<>(columns.size());
+        List<String> values = Arrays.asList(line.split("\t"));
+        String identifier = values.get(0);
+
+        assert values.size() + 1 != columns.size();
+
+        for (int index = 0; index < values.size() - 1; index++) {
+            String key = columns.get(index);
+            String value = values.get(index + 1);
+            result.put(key, value);
+        }
+
+        return new AbstractMap.SimpleEntry<String, Map<String, String>>(
+                identifier, result);
+    }
+}

--- a/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SequenceMetaParserTest.java
+++ b/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SequenceMetaParserTest.java
@@ -1,0 +1,63 @@
+package nl.tudelft.lifetiles.sequence.model;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SequenceMetaParserTest {
+    static final String META_FILE = "/data/meta_data/test.meta";
+    private File file;
+    private SequenceMetaParser parser;
+
+    @Before
+    public void setUp() throws URISyntaxException, IOException {
+        file = new File(this.getClass().getResource(META_FILE).toURI());
+        parser = new SequenceMetaParser();
+        parser.parse(file);
+    }
+
+    @Test
+    public void parserIsParsedTest() {
+        assertTrue(parser.isParsed());
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void parserIsNotParsedTest() {
+        SequenceMetaParser unParser = new SequenceMetaParser();
+        unParser.getData();
+    }
+
+    @Test
+    public void parserColumnsTest() throws IOException {
+        assertArrayEquals(new String[] {
+                "Foo", "Bar"
+        }, parser.getColumns().toArray());
+    }
+
+    @Test
+    public void parserValueTest1() {
+        assertEquals("yes", parser.getData().get("TKK_1").get("Foo"));
+    }
+
+    @Test
+    public void parserValueTest2() {
+        assertEquals("no", parser.getData().get("TKK_1").get("Bar"));
+    }
+
+    @Test
+    public void parserValueTest3() {
+        assertEquals("no", parser.getData().get("TKK_2").get("Foo"));
+    }
+
+    @Test
+    public void parserValueTest4() {
+        assertEquals("yes", parser.getData().get("TKK_2").get("Bar"));
+    }
+}

--- a/lifetiles-sequence/src/test/resources/data/meta_data/test.meta
+++ b/lifetiles-sequence/src/test/resources/data/meta_data/test.meta
@@ -1,0 +1,3 @@
+##ID	Foo	Bar	
+TKK_1	yes	no
+TKK_2	no	yes


### PR DESCRIPTION
The sequence viewer can now display metadata when present as a `.meta` tab-seperated file with header in the data directory.
