### PR TITLE
Stacked Mutation diagram

### DIFF
--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -175,7 +175,7 @@ public class GraphController extends AbstractController {
      * Initialize the zoom toolbar.
      */
     private void initZoomToolBar() {
-        Zoombar toolbar = new Zoombar(MAXZOOM);
+        Zoombar toolbar = new Zoombar(MAX_ZOOM);
         wrapper.setRight(toolbar.getToolBar());
 
         toolbar.getZoomlevel().addListener((observeVal, oldVal, newVal) -> {

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -147,7 +147,7 @@ public class GraphController extends AbstractController {
     /**
      * Maximal zoomed in level.
      */
-    private static final int MAXZOOM = 50;
+    private static final int MAX_ZOOM = 50;
 
     /**
      * The boundary in zoom level between the TileView and the DiagramView.

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -152,7 +152,7 @@ public class GraphController extends AbstractController {
     /**
      * The boundary in zoom level between the TileView and the DiagramView.
      */
-    private static final int SWITCH_ZOOM_LEVEL = 13;
+    private static final int SWITCH_ZOOM_LEVEL = 12;
 
     /**
      * {@inheritDoc}
@@ -220,8 +220,8 @@ public class GraphController extends AbstractController {
 
             visibleSequences = (Set<Sequence>) args[0];
             model.setVisible(visibleSequences);
-            diagram = new StackedMutationContainer(model
-                    .getBucketCache(), visibleSequences);
+            diagram = new StackedMutationContainer(model.getBucketCache(),
+                    visibleSequences);
             repaintNow = true;
             repaint();
         });
@@ -313,7 +313,8 @@ public class GraphController extends AbstractController {
         annotations = new HashMap<>();
 
         model = new GraphContainer(graph, reference);
-        diagram = new StackedMutationContainer(model.getBucketCache(), visibleSequences);
+        diagram = new StackedMutationContainer(model.getBucketCache(),
+                visibleSequences);
 
         shout(Message.LOADED, "sequences", parser.getSequences());
         repaint();
@@ -347,7 +348,8 @@ public class GraphController extends AbstractController {
                 model = new GraphContainer(graph, reference);
             }
             if (diagram == null) {
-                diagram = new StackedMutationContainer(model.getBucketCache(), visibleSequences);
+                diagram = new StackedMutationContainer(model.getBucketCache(),
+                        visibleSequences);
             }
             view = new TileView(this);
             diagramView = new DiagramView();
@@ -400,7 +402,6 @@ public class GraphController extends AbstractController {
                 Group diagramDrawing = new Group();
                 double width = getMaxUnifiedEnd(graph) * scale
                         * VertexView.HORIZONTALSCALE;
-                System.out.println(zoomLevel);
                 int diagramLevel = (zoomLevel - SWITCH_ZOOM_LEVEL) / 2;
                 diagramDrawing.getChildren().add(
                         diagramView.drawDiagram(diagram, diagramLevel, width));
@@ -416,10 +417,11 @@ public class GraphController extends AbstractController {
             int startBucket = bucketLocations[0];
             int endBucket = bucketLocations[1];
 
-            if (currEndPosition != endBucket && currStartPosition != startBucket
-                    || repaintNow) {
+            if (currEndPosition != endBucket
+                    && currStartPosition != startBucket || repaintNow) {
                 Group graphDrawing = new Group();
-                graphDrawing.getChildren().add(drawGraph(startBucket, endBucket));
+                graphDrawing.getChildren().add(
+                        drawGraph(startBucket, endBucket));
                 graphDrawing.getChildren().add(
                         new Rectangle(getMaxUnifiedEnd(graph) * scale
                                 * VertexView.HORIZONTALSCALE, 0));

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -230,7 +230,7 @@ public class GraphController extends AbstractController {
                 (controller, subject, args) -> {
                     assert args.length == 1;
                     assert args[0] instanceof Sequence;
-                    reference = (Sequence) args[0];                
+                    reference = (Sequence) args[0];
                     model = new GraphContainer(graph, reference);
                     model.setVisible(visibleSequences);
                     diagram = new StackedMutationContainer(model

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -47,7 +47,6 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 public class GraphController extends AbstractController {
 
     /**
-<<<<<<< HEAD
      * The pane that will be used to draw the scrollpane and toolbar on the
      * screen.
      */
@@ -130,6 +129,11 @@ public class GraphController extends AbstractController {
      */
     private static final double ZOOM_IN_FACTOR = 2;
     
+    /**
+     * Visible sequences in the graph.
+     */
+    private Set<Sequence> visibleSequences;
+
     /**
      * The current reference in the graph, shouted by the sequence control.
      */
@@ -214,7 +218,10 @@ public class GraphController extends AbstractController {
             assert args.length == 1;
             assert (args[0] instanceof Set<?>);
 
-            model.setVisible((Set<Sequence>) args[0]);
+            visibleSequences = (Set<Sequence>) args[0];
+            model.setVisible(visibleSequences);
+            diagram = new StackedMutationContainer(model
+                    .getBucketCache(), visibleSequences);
             repaintNow = true;
             repaint();
         });
@@ -225,8 +232,9 @@ public class GraphController extends AbstractController {
                     assert args[0] instanceof Sequence;
                     reference = (Sequence) args[0];                
                     model = new GraphContainer(graph, reference);
+                    model.setVisible(visibleSequences);
                     diagram = new StackedMutationContainer(model
-                            .getBucketCache());
+                            .getBucketCache(), visibleSequences);
                     repaintNow = true;
                     repaint();
                 });
@@ -304,6 +312,9 @@ public class GraphController extends AbstractController {
         graph = parser.parseGraph(vertexfile, edgefile, factory);
         annotations = new HashMap<>();
 
+        model = new GraphContainer(graph, reference);
+        diagram = new StackedMutationContainer(model.getBucketCache(), visibleSequences);
+
         shout(Message.LOADED, "sequences", parser.getSequences());
         repaint();
 
@@ -336,7 +347,7 @@ public class GraphController extends AbstractController {
                 model = new GraphContainer(graph, reference);
             }
             if (diagram == null) {
-                diagram = new StackedMutationContainer(model.getBucketCache());
+                diagram = new StackedMutationContainer(model.getBucketCache(), visibleSequences);
             }
             view = new TileView(this);
             diagramView = new DiagramView();

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -128,7 +128,7 @@ public class GraphController extends AbstractController {
      * The factor that each zoom in step that updates the current scale.
      */
     private static final double ZOOM_IN_FACTOR = 2;
-    
+
     /**
      * Visible sequences in the graph.
      */
@@ -152,7 +152,7 @@ public class GraphController extends AbstractController {
     /**
      * The boundary in zoom level between the TileView and the DiagramView.
      */
-    private static final int SWITCH_ZOOM_LEVEL = 17;
+    private static final int SWITCH_ZOOM_LEVEL = 13;
 
     /**
      * {@inheritDoc}
@@ -261,7 +261,7 @@ public class GraphController extends AbstractController {
                         }
                     }
                 });
-        
+
         listen(ANNOTATIONS,
                 (controller, subject, args) -> {
                     assert controller instanceof MenuController;
@@ -395,14 +395,15 @@ public class GraphController extends AbstractController {
      *            Position in the scrollPane.
      */
     private void repaintPosition(final double position) {
-        if (zoomLevel < SWITCH_ZOOM_LEVEL) {
+        if (zoomLevel > SWITCH_ZOOM_LEVEL) {
             if (currentZoomLevel != zoomLevel || repaintNow) {
                 Group diagramDrawing = new Group();
                 double width = getMaxUnifiedEnd(graph) * scale
                         * VertexView.HORIZONTALSCALE;
+                System.out.println(zoomLevel);
+                int diagramLevel = (zoomLevel - SWITCH_ZOOM_LEVEL) / 2;
                 diagramDrawing.getChildren().add(
-                        diagramView.drawDiagram(diagram, 2 + diagram.getLevel()
-                                - zoomLevel, width));
+                        diagramView.drawDiagram(diagram, diagramLevel, width));
                 diagramDrawing.getChildren().add(new Rectangle(width, 0));
                 scrollPane.setContent(diagramDrawing);
 

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/Zoombar.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/Zoombar.java
@@ -35,14 +35,15 @@ public class Zoombar {
     /**
      * Create a new Toolbar.
      *
-     * @param zoom
-     *            the maximal value of the zoom
+     * @param currentZoom
+     *            the current starting zoom level.
+     * @param maxZoom
+     *            the maximal value of the zoom.
      */
-    public Zoombar(final int zoom) {
-        maxzoom = zoom;
+    public Zoombar(final int currentZoom, final int maxZoom) {
+        maxzoom = maxZoom;
         zoomLevel = new SimpleIntegerProperty();
-        // 5 is temporary, until graph can start at the highest zoom level
-        zoomLevel.set(5);
+        zoomLevel.set(currentZoom);
         Slider slider = createSlider();
         slider.getStyleClass().add("slider");
         slider.valueProperty().addListener(
@@ -94,8 +95,8 @@ public class Zoombar {
      * @return the new slider
      */
     private Slider createSlider() {
-        final CustomLabelSlider slider = new CustomLabelSlider(value -> Math
-                .abs(value - maxzoom));
+        final CustomLabelSlider slider = new CustomLabelSlider(
+                value -> Math.abs(value - maxzoom));
 
         slider.setOrientation(Orientation.VERTICAL);
         slider.setMin(0);

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
@@ -58,7 +58,7 @@ public class BucketCache {
         this.numberBuckets = numberBuckets;
         this.graph = graph;
         maxUnifiedEnd = getMaxUnifiedEnd();
-        bucketWidth = maxUnifiedEnd / this.numberBuckets + 1;
+        bucketWidth = (int) Math.pow(2, Math.ceil(Math.log(numberBuckets) / Math.log(2)));
         cacheGraph();
     }
 
@@ -142,7 +142,7 @@ public class BucketCache {
      */
     public final Set<SequenceSegment> getSegments(final int start, final int end) {
         Set<SequenceSegment> set = new TreeSet<SequenceSegment>();
-        for (Set<SequenceSegment> bucket : buckets.subList(start, end)) {
+        for (Set<SequenceSegment> bucket : buckets.subList(Math.max(0, start), Math.min(numberBuckets, end))) {
             set.addAll(bucket);
         }
         return set;

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
@@ -90,10 +90,12 @@ public class BucketCache {
     private void cacheVertex(final SequenceSegment vertex) {
         int startBucket = bucketStartPosition(vertex.getUnifiedStart());
         int endBucket = bucketEndPosition(vertex.getUnifiedEnd());
-
         for (SortedSet<SequenceSegment> bucket : buckets.subList(startBucket,
                 endBucket)) {
             bucket.add(vertex);
+        }
+        if (startBucket == endBucket) {
+            buckets.get(startBucket - 1).add(vertex);
         }
     }
 

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
@@ -55,10 +55,11 @@ public class BucketCache {
      */
     public BucketCache(final int numberBuckets,
             final Graph<SequenceSegment> graph) {
-        this.numberBuckets = numberBuckets;
+        // Number of buckets is ceiled to a power of 2. Needed for diagram view.
+        this.numberBuckets = (int) Math.pow(2, Math.ceil(Math.log(numberBuckets) / Math.log(2)));
         this.graph = graph;
         maxUnifiedEnd = getMaxUnifiedEnd();
-        bucketWidth = (int) Math.pow(2, Math.ceil(Math.log(numberBuckets) / Math.log(2)));
+        bucketWidth = maxUnifiedEnd / this.numberBuckets;
         cacheGraph();
     }
 

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
@@ -145,7 +145,9 @@ public class BucketCache {
      */
     public final Set<SequenceSegment> getSegments(final int start, final int end) {
         Set<SequenceSegment> set = new TreeSet<SequenceSegment>();
-        for (Set<SequenceSegment> bucket : buckets.subList(Math.max(0, start), Math.min(numberBuckets, end))) {
+        int startBucket = Math.max(0, start);
+        int endBucket = Math.min(numberBuckets, end);
+        for (Set<SequenceSegment> bucket : buckets.subList(startBucket, endBucket)) {
             set.addAll(bucket);
         }
         return set;

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/BucketCache.java
@@ -56,7 +56,7 @@ public class BucketCache {
     public BucketCache(final int numberBuckets,
             final Graph<SequenceSegment> graph) {
         // Number of buckets is ceiled to a power of 2. Needed for diagram view.
-        this.numberBuckets = (int) Math.pow(2, Math.ceil(Math.log(numberBuckets) / Math.log(2)));
+        this.numberBuckets = (int) Math.round(Math.pow(2, Math.ceil(Math.log(numberBuckets) / Math.log(2))));
         this.graph = graph;
         maxUnifiedEnd = getMaxUnifiedEnd();
         bucketWidth = maxUnifiedEnd / this.numberBuckets;

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
@@ -128,7 +128,9 @@ public class GraphContainer {
             Set<Sequence> intersect;
             intersect = new HashSet<Sequence>(segment.getSources());
             //check if any of the visible sequences are in this nodes sources
-            intersect.retainAll(visibleSequences);
+            if (visibleSequences != null) {
+            	intersect.retainAll(visibleSequences);
+            }
             if (!intersect.isEmpty()) {
                 vertices.add(segment);
             }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
@@ -62,17 +62,21 @@ public class GraphContainer {
      *
      * @param graph
      *            The initial graph
+     * @param reference
+     *            Reference currently active in the graph controller.
      */
-    public GraphContainer(final Graph<SequenceSegment> graph) {
+    public GraphContainer(final Graph<SequenceSegment> graph,
+            final Sequence reference) {
         this.graph = graph;
-
-        // TODO: Temporary line until sequence selection is implemented.
-        Sequence reference = this.graph.getSources().iterator().next()
-                .getSources().iterator().next();
-
+        for (SequenceSegment segment : this.graph.getAllVertices()) {
+            segment.setReferenceStart(1);
+            segment.setReferenceEnd(Long.MAX_VALUE);
+            segment.setMutation(null);
+        }
         alignGraph();
-        findMutations(reference);
-
+        if (reference != null) {
+            findMutations(reference);
+        }
         segmentBuckets = new BucketCache(graph.getAllVertices().size()
                 / NUM_VERTICES_BUCKET, this.graph);
         visibles = graph.getAllVertices();

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/GraphContainer.java
@@ -123,13 +123,13 @@ public class GraphContainer {
         // Find out which vertices are visible now
         Set<SequenceSegment> vertices = new TreeSet<SequenceSegment>();
 
-        for (SequenceSegment segment: graph.getAllVertices()) {
-            //copy the set of sequences because retainAll modifies the original set
+        for (SequenceSegment segment : graph.getAllVertices()) {
+            // copy the set of sequences because retainAll modifies the original set
             Set<Sequence> intersect;
             intersect = new HashSet<Sequence>(segment.getSources());
-            //check if any of the visible sequences are in this nodes sources
+            // check if any of the visible sequences are in this nodes sources
             if (visibleSequences != null) {
-            	intersect.retainAll(visibleSequences);
+                intersect.retainAll(visibleSequences);
             }
             if (!intersect.isEmpty()) {
                 vertices.add(segment);

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -20,222 +20,222 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
  */
 public class StackedMutationContainer {
 
-	/**
-	 * List with the stacked quantity of mutations.
-	 * <dl>
-	 * <dt>[0] -> total bases.</dt>
-	 * <dt>[1] -> insertion bases.</dt>
-	 * <dt>[2] -> deletion bases.</dt>
-	 * <dt>[3] -> polymorphism bases.</dt>
-	 * </dl>
-	 */
-	private List<List<Long>> stackedMutations;
+    /**
+     * List with the stacked quantity of mutations.
+     * <dl>
+     * <dt>[0] -> total bases.</dt>
+     * <dt>[1] -> insertion bases.</dt>
+     * <dt>[2] -> deletion bases.</dt>
+     * <dt>[3] -> polymorphism bases.</dt>
+     * </dl>
+     */
+    private List<List<Long>> stackedMutations;
 
-	/**
-	 * Child StackedMutationContainer, one level below this stacked mutation
-	 * container.
-	 */
-	private StackedMutationContainer child;
+    /**
+     * Child StackedMutationContainer, one level below this stacked mutation
+     * container.
+     */
+    private StackedMutationContainer child;
 
-	/**
-	 * Zoom/layer level of this stacked mutation container. Level corresponds to
-	 * number of columns inversed.
-	 */
-	private int level;
+    /**
+     * Zoom/layer level of this stacked mutation container. Level corresponds to
+     * number of columns inversed.
+     */
+    private int level;
 
-	/**
-	 * Public constructor for stacked mutation container. Will construct the
-	 * stacked mutation container by calculating the level in comparison with
-	 * the bucketCache.
-	 *
-	 * @param buckets
-	 *            BucketCache to be used to generate the stacked mutation
-	 *            container.
-	 * @param visibleSequences
-	 *            The visible sequences in the graph controller.
-	 */
-	public StackedMutationContainer(final BucketCache buckets,
-			final Set<Sequence> visibleSequences) {
-		this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
-		fillStackedMutationContainer(this.level, buckets, visibleSequences);
-	}
+    /**
+     * Public constructor for stacked mutation container. Will construct the
+     * stacked mutation container by calculating the level in comparison with
+     * the bucketCache.
+     *
+     * @param buckets
+     *            BucketCache to be used to generate the stacked mutation
+     *            container.
+     * @param visibleSequences
+     *            The visible sequences in the graph controller.
+     */
+    public StackedMutationContainer(final BucketCache buckets,
+            final Set<Sequence> visibleSequences) {
+        this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
+        fillStackedMutationContainer(this.level, buckets, visibleSequences);
+    }
 
-	/**
-	 * Private constructor for stacked mutation container. Will construct the
-	 * stacked mutation container based on the given level by the parent stacked
-	 * mutation container.
-	 *
-	 * @param level
-	 *            The level of this stacked mutation container.
-	 * @param buckets
-	 *            The bucketCache to insert into this stackedMutationContainer.
-	 * @param visibleSequences
-	 *            The visible sequences in the graph controller.
-	 */
-	private StackedMutationContainer(final int level,
-			final BucketCache buckets, final Set<Sequence> visibleSequences) {
-		this.level = level;
-		fillStackedMutationContainer(this.level, buckets, visibleSequences);
-	}
+    /**
+     * Private constructor for stacked mutation container. Will construct the
+     * stacked mutation container based on the given level by the parent stacked
+     * mutation container.
+     *
+     * @param level
+     *            The level of this stacked mutation container.
+     * @param buckets
+     *            The bucketCache to insert into this stackedMutationContainer.
+     * @param visibleSequences
+     *            The visible sequences in the graph controller.
+     */
+    private StackedMutationContainer(final int level,
+            final BucketCache buckets, final Set<Sequence> visibleSequences) {
+        this.level = level;
+        fillStackedMutationContainer(this.level, buckets, visibleSequences);
+    }
 
-	/**
-	 * Fills this stacked mutation container with the bucketCache or the child
-	 * stacked mutation container based on the level given.
-	 *
-	 * @param level
-	 *            Level of this stacked mutation container.
-	 * @param buckets
-	 *            BucketCache to be inserted into this stacked mutation
-	 *            container.
-	 * @param visibleSequences
-	 *            The visible sequences in the graph.
-	 */
-	private void fillStackedMutationContainer(final int level,
-			final BucketCache buckets, final Set<Sequence> visibleSequences) {
-		this.level = level;
-		stackedMutations = new ArrayList<>();
-		if (this.level <= 1) {
-			child = null;
-			insertBuckets(buckets, visibleSequences);
-		} else {
-			child = new StackedMutationContainer(level - 1, buckets,
-					visibleSequences);
-			insertStackedMutationContainers(child);
-		}
-	}
+    /**
+     * Fills this stacked mutation container with the bucketCache or the child
+     * stacked mutation container based on the level given.
+     *
+     * @param level
+     *            Level of this stacked mutation container.
+     * @param buckets
+     *            BucketCache to be inserted into this stacked mutation
+     *            container.
+     * @param visibleSequences
+     *            The visible sequences in the graph.
+     */
+    private void fillStackedMutationContainer(final int level,
+            final BucketCache buckets, final Set<Sequence> visibleSequences) {
+        this.level = level;
+        stackedMutations = new ArrayList<>();
+        if (this.level <= 1) {
+            child = null;
+            insertBuckets(buckets, visibleSequences);
+        } else {
+            child = new StackedMutationContainer(level - 1, buckets,
+                    visibleSequences);
+            insertStackedMutationContainers(child);
+        }
+    }
 
-	/**
-	 * Insert the child stacked Mutation Container. Merges the layer of the
-	 * child.
-	 *
-	 * @param containers
-	 *            The child stacked mutation container.
-	 */
-	private void insertStackedMutationContainers(
-			final StackedMutationContainer containers) {
-		for (int index = 0; index < containers.getStack().size() / 2; index++) {
-			stackedMutations.add(insertStackedContainer(containers.getStack()
-					.get(2 * index), containers.getStack().get(2 * index + 1)));
-		}
-	}
+    /**
+     * Insert the child stacked Mutation Container. Merges the layer of the
+     * child.
+     *
+     * @param containers
+     *            The child stacked mutation container.
+     */
+    private void insertStackedMutationContainers(
+            final StackedMutationContainer containers) {
+        for (int index = 0; index < containers.getStack().size() / 2; index++) {
+            stackedMutations.add(insertStackedContainer(containers.getStack()
+                    .get(2 * index), containers.getStack().get(2 * index + 1)));
+        }
+    }
 
-	/**
-	 * Insert two sections of the child stacked Mutation Container into one
-	 * section of the stacked Mutation Container.
-	 *
-	 * @param left
-	 *            Left section of the child stacked mutation container.
-	 * @param right
-	 *            Right section of the child stacked mutation container.
-	 * @return merged section for this stacked mutation container.
-	 */
-	private List<Long> insertStackedContainer(final List<Long> left,
-			final List<Long> right) {
-		List<Long> stack = new ArrayList<>();
-		for (int index = 0; index < left.size(); index++) {
-			stack.add(left.get(index) + right.get(index));
-		}
-		return stack;
-	}
+    /**
+     * Insert two sections of the child stacked Mutation Container into one
+     * section of the stacked Mutation Container.
+     *
+     * @param left
+     *            Left section of the child stacked mutation container.
+     * @param right
+     *            Right section of the child stacked mutation container.
+     * @return merged section for this stacked mutation container.
+     */
+    private List<Long> insertStackedContainer(final List<Long> left,
+            final List<Long> right) {
+        List<Long> stack = new ArrayList<>();
+        for (int index = 0; index < left.size(); index++) {
+            stack.add(left.get(index) + right.get(index));
+        }
+        return stack;
+    }
 
-	/**
-	 * Returns all columns in the stacked mutation diagram.
-	 *
-	 * @return all columns in the stacked mutation diagram.
-	 */
-	public List<List<Long>> getStack() {
-		return stackedMutations;
-	}
+    /**
+     * Returns all columns in the stacked mutation diagram.
+     *
+     * @return all columns in the stacked mutation diagram.
+     */
+    public List<List<Long>> getStack() {
+        return stackedMutations;
+    }
 
-	/**
-	 * Insert the buckets into the mutation quantity list.
-	 *
-	 * @param buckets
-	 *            BucketCache which needs to be added to the stacked mutation
-	 *            container.
-	 * @param visibleSequences
-	 *            The visible sequences in the graph.
-	 */
-	private void insertBuckets(final BucketCache buckets,
-			final Set<Sequence> visibleSequences) {
-		for (Set<SequenceSegment> bucket : buckets.getBuckets()) {
-			stackedMutations.add(insertBucket(bucket, visibleSequences));
-		}
-	}
+    /**
+     * Insert the buckets into the mutation quantity list.
+     *
+     * @param buckets
+     *            BucketCache which needs to be added to the stacked mutation
+     *            container.
+     * @param visibleSequences
+     *            The visible sequences in the graph.
+     */
+    private void insertBuckets(final BucketCache buckets,
+            final Set<Sequence> visibleSequences) {
+        for (Set<SequenceSegment> bucket : buckets.getBuckets()) {
+            stackedMutations.add(insertBucket(bucket, visibleSequences));
+        }
+    }
 
-	/**
-	 * Insert the bucket into the mutation quantity list.
-	 *
-	 * @param bucket
-	 *            Bucket from bucketCache which needs to be added to the stacked
-	 *            mutation container.
-	 * @param visibleSequences
-	 *            The visible sequences in the graph.
-	 * @return stacked mutation quantity list for this bucket.
-	 */
-	private List<Long> insertBucket(final Set<SequenceSegment> bucket,
-			final Set<Sequence> visibleSequences) {
-		List<Long> list = new ArrayList<>(4);
-		list.add((long) 0);
-		list.add((long) 0);
-		list.add((long) 0);
-		list.add((long) 0);
+    /**
+     * Insert the bucket into the mutation quantity list.
+     *
+     * @param bucket
+     *            Bucket from bucketCache which needs to be added to the stacked
+     *            mutation container.
+     * @param visibleSequences
+     *            The visible sequences in the graph.
+     * @return stacked mutation quantity list for this bucket.
+     */
+    private List<Long> insertBucket(final Set<SequenceSegment> bucket,
+            final Set<Sequence> visibleSequences) {
+        List<Long> list = new ArrayList<>(4);
+        list.add((long) 0);
+        list.add((long) 0);
+        list.add((long) 0);
+        list.add((long) 0);
 
-		Map<Mutation, Integer> mutations = new HashMap<>();
-		mutations.put(Mutation.INSERTION, 1);
-		mutations.put(Mutation.DELETION, 1);
-		mutations.put(Mutation.POLYMORPHISM, 1);
+        Map<Mutation, Integer> mutations = new HashMap<>();
+        mutations.put(Mutation.INSERTION, 1);
+        mutations.put(Mutation.DELETION, 1);
+        mutations.put(Mutation.POLYMORPHISM, 1);
 
-		for (SequenceSegment segment : bucket) {
-			Set<Sequence> sources = new HashSet<>(segment.getSources());
-			if (visibleSequences != null) {
-				sources.retainAll(visibleSequences);
-			}
-			long size = segment.getContent().getLength() * sources.size();
-			if (mutations.containsKey(segment.getMutation())) {
-				int index = mutations.get(segment.getMutation());
-				list.set(index, list.get(index) + size);
-			}
-			list.set(0, list.get(0) + size);
-		}
-		return list;
-	}
+        for (SequenceSegment segment : bucket) {
+            Set<Sequence> sources = new HashSet<>(segment.getSources());
+            if (visibleSequences != null) {
+                sources.retainAll(visibleSequences);
+            }
+            long size = segment.getContent().getLength() * sources.size();
+            if (mutations.containsKey(segment.getMutation())) {
+                int index = mutations.get(segment.getMutation());
+                list.set(index, list.get(index) + size);
+            }
+            list.set(0, list.get(0) + size);
+        }
+        return list;
+    }
 
-	/**
-	 * Return the maximum number of mutations in one of the stacks.
-	 *
-	 * @return the maximum number of mutations in one of the stacks.
-	 */
-	public Long getMaxMutations() {
-		long max = 0;
-		for (List<Long> stack : stackedMutations) {
-			max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
-		}
-		return max;
-	}
+    /**
+     * Return the maximum number of mutations in one of the stacks.
+     *
+     * @return the maximum number of mutations in one of the stacks.
+     */
+    public Long getMaxMutations() {
+        long max = 0;
+        for (List<Long> stack : stackedMutations) {
+            max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
+        }
+        return max;
+    }
 
-	/**
-	 * Returns a map from level to stacked container.
-	 *
-	 * @return map from level to stacked container.
-	 */
-	public Map<Integer, StackedMutationContainer> mapLevelStackedMutation() {
-		Map<Integer, StackedMutationContainer> map;
-		if (child == null) {
-			map = new HashMap<>();
-		} else {
-			map = child.mapLevelStackedMutation();
-		}
-		map.put(getLevel(), this);
-		return map;
+    /**
+     * Returns a map from level to stacked container.
+     *
+     * @return map from level to stacked container.
+     */
+    public Map<Integer, StackedMutationContainer> mapLevelStackedMutation() {
+        Map<Integer, StackedMutationContainer> map;
+        if (child == null) {
+            map = new HashMap<>();
+        } else {
+            map = child.mapLevelStackedMutation();
+        }
+        map.put(getLevel(), this);
+        return map;
 
-	}
+    }
 
-	/**
-	 * @return the level
-	 */
-	public int getLevel() {
-		return level;
-	}
+    /**
+     * @return the level
+     */
+    public int getLevel() {
+        return level;
+    }
 
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import nl.tudelft.lifetiles.sequence.Mutation;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
@@ -19,224 +20,222 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
  */
 public class StackedMutationContainer {
 
-    /**
-     * List with the stacked quantity of mutations.
-     * <dl>
-     * <dt>[0] -> total bases.</dt>
-     * <dt>[1] -> insertion bases.</dt>
-     * <dt>[2] -> deletion bases.</dt>
-     * <dt>[3] -> polymorphism bases.</dt>
-     * </dl>
-     */
-    private List<List<Long>> stackedMutations;
+	/**
+	 * List with the stacked quantity of mutations.
+	 * <dl>
+	 * <dt>[0] -> total bases.</dt>
+	 * <dt>[1] -> insertion bases.</dt>
+	 * <dt>[2] -> deletion bases.</dt>
+	 * <dt>[3] -> polymorphism bases.</dt>
+	 * </dl>
+	 */
+	private List<List<Long>> stackedMutations;
 
-    /**
-     * Child StackedMutationContainer, one level below this stacked mutation
-     * container.
-     */
-    private StackedMutationContainer child;
+	/**
+	 * Child StackedMutationContainer, one level below this stacked mutation
+	 * container.
+	 */
+	private StackedMutationContainer child;
 
-    /**
-     * Zoom/layer level of this stacked mutation container. Level corresponds to
-     * number of columns inversed.
-     */
-    private int level;
+	/**
+	 * Zoom/layer level of this stacked mutation container. Level corresponds to
+	 * number of columns inversed.
+	 */
+	private int level;
 
-    /**
-     * Public constructor for stacked mutation container.
-     * Will construct the stacked mutation container by calculating the level in
-     * comparison with the bucketCache.
-     *
-     * @param buckets
-     *            BucketCache to be used to generate the stacked mutation
-     *            container.
-     */
-    public StackedMutationContainer(final BucketCache buckets,
-            final Set<Sequence> visibleSequences) {
-        this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
-        fillStackedMutationContainer(this.level, buckets, visibleSequences);
-    }
+	/**
+	 * Public constructor for stacked mutation container. Will construct the
+	 * stacked mutation container by calculating the level in comparison with
+	 * the bucketCache.
+	 *
+	 * @param buckets
+	 *            BucketCache to be used to generate the stacked mutation
+	 *            container.
+	 * @param visibleSequences
+	 *            The visible sequences in the graph controller.
+	 */
+	public StackedMutationContainer(final BucketCache buckets,
+			final Set<Sequence> visibleSequences) {
+		this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
+		fillStackedMutationContainer(this.level, buckets, visibleSequences);
+	}
 
-    /**
-     * Private constructor for stacked mutation container.
-     * Will construct the stacked mutation container based on the given level by
-     * the parent stacked mutation container.
-     *
-     * @param level
-     *            The level of this stacked mutation container.
-     * @param buckets
-     *            The bucketCache to insert into this stackedMutationContainer.
-     */
-    private StackedMutationContainer(final int level,
-            final BucketCache buckets, final Set<Sequence> visibleSequences) {
-        this.level = level;
-        fillStackedMutationContainer(this.level, buckets, visibleSequences);
-    }
+	/**
+	 * Private constructor for stacked mutation container. Will construct the
+	 * stacked mutation container based on the given level by the parent stacked
+	 * mutation container.
+	 *
+	 * @param level
+	 *            The level of this stacked mutation container.
+	 * @param buckets
+	 *            The bucketCache to insert into this stackedMutationContainer.
+	 * @param visibleSequences
+	 *            The visible sequences in the graph controller.
+	 */
+	private StackedMutationContainer(final int level,
+			final BucketCache buckets, final Set<Sequence> visibleSequences) {
+		this.level = level;
+		fillStackedMutationContainer(this.level, buckets, visibleSequences);
+	}
 
-    /**
-     * Fills this stacked mutation container with the bucketCache or the child
-     * stacked mutation container based on the level given.
-     *
-     * @param level
-     *            Level of this stacked mutation container.
-     * @param buckets
-     *            BucketCache to be inserted into this stacked mutation
-     *            container.
-     * @param visibleSequences
-     *            The visible sequences in the graph.
-     */
-    private void fillStackedMutationContainer(final int level,
-            final BucketCache buckets, final Set<Sequence> visibleSequences) {
-        this.level = level;
-        stackedMutations = new ArrayList<>();
-        if (this.level <= 1) {
-            child = null;
-            insertBuckets(buckets, visibleSequences);
-        } else {
-            child = new StackedMutationContainer(level - 1, buckets,
-                    visibleSequences);
-            insertStackedMutationContainers(child);
-        }
-    }
+	/**
+	 * Fills this stacked mutation container with the bucketCache or the child
+	 * stacked mutation container based on the level given.
+	 *
+	 * @param level
+	 *            Level of this stacked mutation container.
+	 * @param buckets
+	 *            BucketCache to be inserted into this stacked mutation
+	 *            container.
+	 * @param visibleSequences
+	 *            The visible sequences in the graph.
+	 */
+	private void fillStackedMutationContainer(final int level,
+			final BucketCache buckets, final Set<Sequence> visibleSequences) {
+		this.level = level;
+		stackedMutations = new ArrayList<>();
+		if (this.level <= 1) {
+			child = null;
+			insertBuckets(buckets, visibleSequences);
+		} else {
+			child = new StackedMutationContainer(level - 1, buckets,
+					visibleSequences);
+			insertStackedMutationContainers(child);
+		}
+	}
 
-    /**
-     * Insert the child stacked Mutation Container.
-     * Merges the layer of the child.
-     *
-     * @param containers
-     *            The child stacked mutation container.
-     */
-    private void insertStackedMutationContainers(
-            final StackedMutationContainer containers) {
-        for (int index = 0; index < containers.getStack().size() / 2; index++) {
-            stackedMutations.add(insertStackedContainer(containers.getStack()
-                    .get(2 * index), containers.getStack().get(2 * index + 1)));
-        }
-    }
+	/**
+	 * Insert the child stacked Mutation Container. Merges the layer of the
+	 * child.
+	 *
+	 * @param containers
+	 *            The child stacked mutation container.
+	 */
+	private void insertStackedMutationContainers(
+			final StackedMutationContainer containers) {
+		for (int index = 0; index < containers.getStack().size() / 2; index++) {
+			stackedMutations.add(insertStackedContainer(containers.getStack()
+					.get(2 * index), containers.getStack().get(2 * index + 1)));
+		}
+	}
 
-    /**
-     * Insert two sections of the child stacked Mutation Container into one
-     * section of the stacked Mutation Container.
-     *
-     * @param left
-     *            Left section of the child stacked mutation container.
-     * @param right
-     *            Right section of the child stacked mutation container.
-     * @return merged section for this stacked mutation container.
-     */
-    private List<Long> insertStackedContainer(final List<Long> left,
-            final List<Long> right) {
-        List<Long> stack = new ArrayList<>();
-        for(int index = 0; index < left.size(); index++) {
-            stack.add(left.get(index) + right.get(index));
-        }
-        return stack;
-    }
+	/**
+	 * Insert two sections of the child stacked Mutation Container into one
+	 * section of the stacked Mutation Container.
+	 *
+	 * @param left
+	 *            Left section of the child stacked mutation container.
+	 * @param right
+	 *            Right section of the child stacked mutation container.
+	 * @return merged section for this stacked mutation container.
+	 */
+	private List<Long> insertStackedContainer(final List<Long> left,
+			final List<Long> right) {
+		List<Long> stack = new ArrayList<>();
+		for (int index = 0; index < left.size(); index++) {
+			stack.add(left.get(index) + right.get(index));
+		}
+		return stack;
+	}
 
-    /**
-     * Returns all columns in the stacked mutation diagram.
-     *
-     * @return all columns in the stacked mutation diagram.
-     */
-    public List<List<Long>> getStack() {
-        return stackedMutations;
-    }
+	/**
+	 * Returns all columns in the stacked mutation diagram.
+	 *
+	 * @return all columns in the stacked mutation diagram.
+	 */
+	public List<List<Long>> getStack() {
+		return stackedMutations;
+	}
 
-    /**
-     * Insert the buckets into the mutation quantity list.
-     *
-     * @param buckets
-     *            BucketCache which needs to be added to the stacked mutation
-     *            container.
-     * @param visibleSequences
-     *            The visible sequences in the graph.
-     */
-    private void insertBuckets(final BucketCache buckets,
-            Set<Sequence> visibleSequences) {
-        for (Set<SequenceSegment> bucket : buckets.getBuckets()) {
-            stackedMutations.add(insertBucket(bucket, visibleSequences));
-        }
-    }
+	/**
+	 * Insert the buckets into the mutation quantity list.
+	 *
+	 * @param buckets
+	 *            BucketCache which needs to be added to the stacked mutation
+	 *            container.
+	 * @param visibleSequences
+	 *            The visible sequences in the graph.
+	 */
+	private void insertBuckets(final BucketCache buckets,
+			final Set<Sequence> visibleSequences) {
+		for (Set<SequenceSegment> bucket : buckets.getBuckets()) {
+			stackedMutations.add(insertBucket(bucket, visibleSequences));
+		}
+	}
 
-    /**
-     * Insert the bucket into the mutation quantity list.
-     *
-     * @param bucket
-     *            Bucket from bucketCache which needs to be added to the stacked
-     *            mutation container.
-     * @param visibleSequences
-     *            The visible sequences in the graph.
-     * @return stacked mutation quantity list for this bucket.
-     */
-    private List<Long> insertBucket(final Set<SequenceSegment> bucket,
-            Set<Sequence> visibleSequences) {
-        List<Long> list = new ArrayList<>(4);
-        list.add((long) 0);
-        list.add((long) 0);
-        list.add((long) 0);
-        list.add((long) 0);
+	/**
+	 * Insert the bucket into the mutation quantity list.
+	 *
+	 * @param bucket
+	 *            Bucket from bucketCache which needs to be added to the stacked
+	 *            mutation container.
+	 * @param visibleSequences
+	 *            The visible sequences in the graph.
+	 * @return stacked mutation quantity list for this bucket.
+	 */
+	private List<Long> insertBucket(final Set<SequenceSegment> bucket,
+			final Set<Sequence> visibleSequences) {
+		List<Long> list = new ArrayList<>(4);
+		list.add((long) 0);
+		list.add((long) 0);
+		list.add((long) 0);
+		list.add((long) 0);
 
-        for (SequenceSegment segment : bucket) {
-            Set<Sequence> sources = new HashSet<>(segment.getSources());
-            if (visibleSequences != null) {
-                sources.retainAll(visibleSequences);
-            }
-            long size = segment.getContent().getLength() * sources.size();
-            if (segment.getMutation() != null) {
-                switch (segment.getMutation()) {
-                case INSERTION:
-                    list.set(1, list.get(1) + size);
-                    break;
-                case DELETION:
-                    list.set(2, list.get(2) + size);
-                    break;
-                case POLYMORPHISM:
-                    list.set(3, list.get(3) + size);
-                    break;
-                default: // noop
-                    break;
-                }
-            }
-            list.set(0, list.get(0) + size);
-        }
-        return list;
-    }
+		Map<Mutation, Integer> mutations = new HashMap<>();
+		mutations.put(Mutation.INSERTION, 1);
+		mutations.put(Mutation.DELETION, 1);
+		mutations.put(Mutation.POLYMORPHISM, 1);
 
-    /**
-     * Return the maximum number of mutations in one of the stacks.
-     *
-     * @return the maximum number of mutations in one of the stacks.
-     */
-    public Long getMaxMutations() {
-        long max = 0;
-        for (List<Long> stack : stackedMutations) {
-            max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
-        }
-        return max;
-    }
+		for (SequenceSegment segment : bucket) {
+			Set<Sequence> sources = new HashSet<>(segment.getSources());
+			if (visibleSequences != null) {
+				sources.retainAll(visibleSequences);
+			}
+			long size = segment.getContent().getLength() * sources.size();
+			if (mutations.containsKey(segment.getMutation())) {
+				int index = mutations.get(segment.getMutation());
+				list.set(index, list.get(index) + size);
+			}
+			list.set(0, list.get(0) + size);
+		}
+		return list;
+	}
 
-    /**
-     * Returns a map from level to stacked container.
-     *
-     * @return map from level to stacked container.
-     */
-    public Map<Integer, StackedMutationContainer> mapLevelStackedMutation() {
-        Map<Integer, StackedMutationContainer> map;
-        if (child == null) {
-            map = new HashMap<>();
-        } else {
-            map = child.mapLevelStackedMutation();
-        }
-        map.put(getLevel(), this);
-        return map;
+	/**
+	 * Return the maximum number of mutations in one of the stacks.
+	 *
+	 * @return the maximum number of mutations in one of the stacks.
+	 */
+	public Long getMaxMutations() {
+		long max = 0;
+		for (List<Long> stack : stackedMutations) {
+			max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
+		}
+		return max;
+	}
 
-    }
+	/**
+	 * Returns a map from level to stacked container.
+	 *
+	 * @return map from level to stacked container.
+	 */
+	public Map<Integer, StackedMutationContainer> mapLevelStackedMutation() {
+		Map<Integer, StackedMutationContainer> map;
+		if (child == null) {
+			map = new HashMap<>();
+		} else {
+			map = child.mapLevelStackedMutation();
+		}
+		map.put(getLevel(), this);
+		return map;
 
-    /**
-     * @return the level
-     */
-    public int getLevel() {
-        return level;
-    }
+	}
+
+	/**
+	 * @return the level
+	 */
+	public int getLevel() {
+		return level;
+	}
 
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -21,12 +21,36 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 public class StackedMutationContainer {
 
     /**
+     * Mapping value of the insertion mutation.
+     */
+    private static final Integer INSERTION_MAP = 1;
+
+    /**
+     * Mapping value of the deletion mutation.
+     */
+    private static final Integer DELETION_MAP = 2;
+
+    /**
+     * Mapping value of the polymorphism mutation.
+     */
+    private static final Integer POLYMORPHISM_MAP = 3;
+
+    /**
+     * The number of values being counted by the stacked mutation container.
+     */
+    private static final int NUMBER_OF_VALUES = 4;
+
+    /**
      * List with the stacked quantity of mutations.
      * <dl>
-     * <dt>[0] -> total bases.</dt>
-     * <dt>[1] -> insertion bases.</dt>
-     * <dt>[2] -> deletion bases.</dt>
-     * <dt>[3] -> polymorphism bases.</dt>
+     * <dt>[0]</dt>
+     * <dd>total bases.</dd>
+     * <dt>[1]</dt>
+     * <dd>insertion bases.</dd>
+     * <dt>[2]</dt>
+     * <dd>deletion bases.</dd>
+     * <dt>[3]</dt>
+     * <dd>polymorphism bases.</dd>
      * </dl>
      */
     private List<List<Long>> stackedMutations;
@@ -56,7 +80,8 @@ public class StackedMutationContainer {
      */
     public StackedMutationContainer(final BucketCache buckets,
             final Set<Sequence> visibleSequences) {
-        this.level = (int) Math.round(Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
+        this.level = (int) Math.round(Math.log(buckets.getNumberBuckets())
+                / Math.log(2) + 1);
         fillStackedMutationContainer(this.level, buckets, visibleSequences);
     }
 
@@ -175,16 +200,15 @@ public class StackedMutationContainer {
      */
     private List<Long> insertBucket(final Set<SequenceSegment> bucket,
             final Set<Sequence> visibleSequences) {
-        List<Long> list = new ArrayList<>(4);
-        list.add((long) 0);
-        list.add((long) 0);
-        list.add((long) 0);
-        list.add((long) 0);
+        List<Long> list = new ArrayList<>(NUMBER_OF_VALUES);
+        for (int index = 0; index < NUMBER_OF_VALUES; index++) {
+            list.add((long) 0);
+        }
 
-        Map<Mutation, Integer> mutations = new HashMap<>();
-        mutations.put(Mutation.INSERTION, 1);
-        mutations.put(Mutation.DELETION, 2);
-        mutations.put(Mutation.POLYMORPHISM, 3);
+        Map<Mutation, Integer> mutations = new HashMap<>(3);
+        mutations.put(Mutation.INSERTION, INSERTION_MAP);
+        mutations.put(Mutation.DELETION, DELETION_MAP);
+        mutations.put(Mutation.POLYMORPHISM, POLYMORPHISM_MAP);
 
         for (SequenceSegment segment : bucket) {
             Set<Sequence> sources = new HashSet<>(segment.getSources());

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -88,14 +88,13 @@ public class StackedMutationContainer {
     private void fillStackedMutationContainer(final int level,
             final BucketCache buckets, final Set<Sequence> visibleSequences) {
         this.level = level;
+        stackedMutations = new ArrayList<>();
         if (this.level <= 1) {
             child = null;
-            stackedMutations = new ArrayList<List<Long>>();
             insertBuckets(buckets, visibleSequences);
         } else {
             child = new StackedMutationContainer(level - 1, buckets,
                     visibleSequences);
-            stackedMutations = new ArrayList<List<Long>>();
             insertStackedMutationContainers(child);
         }
     }
@@ -127,11 +126,10 @@ public class StackedMutationContainer {
      */
     private List<Long> insertStackedContainer(final List<Long> left,
             final List<Long> right) {
-        List<Long> stack = new ArrayList<Long>();
-        stack.add(left.get(0) + right.get(0));
-        stack.add(left.get(1) + right.get(1));
-        stack.add(left.get(2) + right.get(2));
-        stack.add(left.get(3) + right.get(3));
+        List<Long> stack = new ArrayList<>();
+        for(int index = 0; index < left.size(); index++) {
+            stack.add(left.get(index) + right.get(index));
+        }
         return stack;
     }
 
@@ -172,7 +170,7 @@ public class StackedMutationContainer {
      */
     private List<Long> insertBucket(final Set<SequenceSegment> bucket,
             Set<Sequence> visibleSequences) {
-        List<Long> list = new ArrayList<Long>(4);
+        List<Long> list = new ArrayList<>(4);
         list.add((long) 0);
         list.add((long) 0);
         list.add((long) 0);

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -1,0 +1,225 @@
+package nl.tudelft.lifetiles.graph.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+
+/**
+ * Container including the stacks with the mutation quantity used for drawing
+ * the stacked mutation quantity diagram.
+ *
+ * @author Jos
+ *
+ */
+public class StackedMutationContainer {
+
+    /**
+     * List with the stacked quantity of mutations.
+     * [0] -> total bases.
+     * [1] -> insertion bases.
+     * [2] -> deletion bases.
+     * [3] -> polymorphism bases.
+     */
+    private List<List<Long>> stackedMutations;
+
+    /**
+     * Child StackedMutationContainer, one level below this stacked mutation
+     * container.
+     */
+    private StackedMutationContainer child;
+
+    /**
+     * Zoom/layer level of this stacked mutation container. Level corresponds to
+     * number of columns inversed.
+     */
+    private int level;
+
+    /**
+     * Public constructor for stacked mutation container.
+     * Will construct the stacked mutation container by calculating the level in
+     * comparison with the bucketCache.
+     *
+     * @param buckets
+     *            BucketCache to be used to generate the stacked mutation
+     *            container.
+     */
+    public StackedMutationContainer(final BucketCache buckets) {
+        this.level =(int) Math.ceil(Math.log(buckets.getNumberBuckets())
+                / Math.log(2)) + 1;
+        fillStackedMutationContainer(getLevel(), buckets);
+    }
+
+    /**
+     * Private constructor for stacked mutation container.
+     * Will construct the stacked mutation container based on the given level by
+     * the parent stacked mutation container.
+     *
+     * @param level
+     *            The level of this stacked mutation container.
+     * @param buckets
+     *            The bucketCache to insert into this stackedMutationContainer.
+     */
+    private StackedMutationContainer(final int level, final BucketCache buckets) {
+        this.level = level;
+        fillStackedMutationContainer(this.getLevel(), buckets);
+    }
+
+    /**
+     * Fills this stacked mutation container with the bucketCache or the child
+     * stacked mutation container based on the level given.
+     *
+     * @param level
+     *            Level of this stacked mutation container.
+     * @param buckets
+     *            BucketCache to be inserted into this stacked mutation
+     *            container.
+     */
+    private void fillStackedMutationContainer(final int level,
+            final BucketCache buckets) {
+        this.level = level;
+        if (this.getLevel() <= 1) {
+            child = null;
+            stackedMutations = new ArrayList<List<Long>>();
+            insertBuckets(buckets);
+        } else {
+            child = new StackedMutationContainer(level - 1, buckets);
+            stackedMutations = new ArrayList<List<Long>>();
+            insertStackedMutationContainers(child);
+        }
+    }
+
+    /**
+     * Insert the child stacked Mutation Container.
+     * Merges the layer of the child.
+     *
+     * @param containers
+     *            The child stacked mutation container.
+     */
+    private void insertStackedMutationContainers(
+            final StackedMutationContainer containers) {
+        for (int index = 0; index < containers.getStack().size() / 2; index++) {
+            stackedMutations.add(insertStackedContainer(containers.getStack()
+                    .get(2 * index), containers.getStack().get(2 * index + 1)));
+        }
+    }
+
+    /**
+     * Insert two sections of the child stacked Mutation Container into one
+     * section of the stacked Mutation Container.
+     *
+     * @param left
+     *            Left section of the child stacked mutation container.
+     * @param right
+     *            Right section of the child stacked mutation container.
+     * @return merged section for this stacked mutation container.
+     */
+    private List<Long> insertStackedContainer(final List<Long> left,
+            final List<Long> right) {
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add(left.get(0) + right.get(0));
+        stack.add(left.get(1) + right.get(1));
+        stack.add(left.get(2) + right.get(2));
+        stack.add(left.get(3) + right.get(3));
+        return stack;
+    }
+
+    /**
+     * Returns all columns in the stacked mutation diagram.
+     *
+     * @return all columns in the stacked mutation diagram.
+     */
+    public List<List<Long>> getStack() {
+        return stackedMutations;
+    }
+
+    /**
+     * Insert the buckets into the mutation quantity list.
+     *
+     * @param buckets
+     *            BucketCache which needs to be added to the stacked mutation
+     *            container.
+     */
+    private void insertBuckets(final BucketCache buckets) {
+        for (SortedSet<SequenceSegment> bucket : buckets.getBuckets()) {
+            stackedMutations.add(insertBucket(bucket));
+        }
+    }
+
+    /**
+     * Insert the bucket into the mutation quantity list.
+     *
+     * @param bucket
+     *            Bucket from bucketCache which needs to be added to the stacked
+     *            mutation container.
+     * @return
+     *         Stacked mutation quantity list for this bucket.
+     */
+    private List<Long> insertBucket(final SortedSet<SequenceSegment> bucket) {
+        ArrayList<Long> list = new ArrayList<Long>();
+        long total = 0;
+        long insertion = 0;
+        long deletion = 0;
+        long polymorphism = 0;
+        for (SequenceSegment segment : bucket) {
+            long size = segment.getContent().getLength() * segment.getSources().size();
+            if (segment.getMutation() != null) {
+                switch (segment.getMutation()) {
+                case INSERTION:
+                    insertion += size;
+                    break;
+                case DELETION:
+                    deletion += size;
+                    break;
+                case POLYMORPHISM:
+                    polymorphism += size;
+                    break;
+                default: // noop
+                    break;
+                }
+            }
+            total += size;
+        }
+        list.add(total);
+        list.add(insertion);
+        list.add(deletion);
+        list.add(polymorphism);
+        return list;
+    }
+    
+    public Long getMaxMutations() {
+    	long max = 0;
+    	for (List<Long> stack : stackedMutations) {
+    		max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
+    	}
+    	return max;
+    }
+
+    /**
+     * Returns a map from level to stacked container.
+     *
+     * @return map from level to stacked container.
+     */
+    public Map<Integer, StackedMutationContainer> mapLevelStackedMutation() {
+        Map<Integer, StackedMutationContainer> map;
+        if (child == null) {
+            map = new HashMap<>();
+        } else {
+            map = child.mapLevelStackedMutation();
+        }
+        map.put(getLevel(), this);
+        return map;
+
+    }
+
+	/**
+	 * @return the level
+	 */
+	public int getLevel() {
+		return level;
+	}
+
+}

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedSet;
+import java.util.Set;
 
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
@@ -19,10 +19,12 @@ public class StackedMutationContainer {
 
     /**
      * List with the stacked quantity of mutations.
-     * [0] -> total bases.
-     * [1] -> insertion bases.
-     * [2] -> deletion bases.
-     * [3] -> polymorphism bases.
+     * <dl>
+     * <dt>[0] -> total bases.</dt>
+     * <dt>[1] -> insertion bases.</dt>
+     * <dt>[2] -> deletion bases.</dt>
+     * <dt>[3] -> polymorphism bases.</dt>
+     * </dl>
      */
     private List<List<Long>> stackedMutations;
 
@@ -48,9 +50,8 @@ public class StackedMutationContainer {
      *            container.
      */
     public StackedMutationContainer(final BucketCache buckets) {
-        this.level =(int) Math.ceil(Math.log(buckets.getNumberBuckets())
-                / Math.log(2)) + 1;
-        fillStackedMutationContainer(getLevel(), buckets);
+        this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
+        fillStackedMutationContainer(this.level, buckets);
     }
 
     /**
@@ -65,7 +66,7 @@ public class StackedMutationContainer {
      */
     private StackedMutationContainer(final int level, final BucketCache buckets) {
         this.level = level;
-        fillStackedMutationContainer(this.getLevel(), buckets);
+        fillStackedMutationContainer(this.level, buckets);
     }
 
     /**
@@ -81,7 +82,7 @@ public class StackedMutationContainer {
     private void fillStackedMutationContainer(final int level,
             final BucketCache buckets) {
         this.level = level;
-        if (this.getLevel() <= 1) {
+        if (this.level <= 1) {
             child = null;
             stackedMutations = new ArrayList<List<Long>>();
             insertBuckets(buckets);
@@ -119,7 +120,7 @@ public class StackedMutationContainer {
      */
     private List<Long> insertStackedContainer(final List<Long> left,
             final List<Long> right) {
-        ArrayList<Long> stack = new ArrayList<Long>();
+        List<Long> stack = new ArrayList<Long>();
         stack.add(left.get(0) + right.get(0));
         stack.add(left.get(1) + right.get(1));
         stack.add(left.get(2) + right.get(2));
@@ -144,7 +145,7 @@ public class StackedMutationContainer {
      *            container.
      */
     private void insertBuckets(final BucketCache buckets) {
-        for (SortedSet<SequenceSegment> bucket : buckets.getBuckets()) {
+        for (Set<SequenceSegment> bucket : buckets.getBuckets()) {
             stackedMutations.add(insertBucket(bucket));
         }
     }
@@ -158,44 +159,47 @@ public class StackedMutationContainer {
      * @return
      *         Stacked mutation quantity list for this bucket.
      */
-    private List<Long> insertBucket(final SortedSet<SequenceSegment> bucket) {
-        ArrayList<Long> list = new ArrayList<Long>();
-        long total = 0;
-        long insertion = 0;
-        long deletion = 0;
-        long polymorphism = 0;
+    private List<Long> insertBucket(final Set<SequenceSegment> bucket) {
+        List<Long> list = new ArrayList<Long>(4);
+        list.add((long) 0);
+        list.add((long) 0);
+        list.add((long) 0);
+        list.add((long) 0);
+
         for (SequenceSegment segment : bucket) {
-            long size = segment.getContent().getLength() * segment.getSources().size();
+            long size = segment.getContent().getLength()
+                    * segment.getSources().size();
             if (segment.getMutation() != null) {
                 switch (segment.getMutation()) {
                 case INSERTION:
-                    insertion += size;
+                    list.set(1, list.get(1) + size);
                     break;
                 case DELETION:
-                    deletion += size;
+                    list.set(2, list.get(2) + size);
                     break;
                 case POLYMORPHISM:
-                    polymorphism += size;
+                    list.set(3, list.get(3) + size);
                     break;
                 default: // noop
                     break;
                 }
             }
-            total += size;
+            list.set(0, list.get(0) + size);
         }
-        list.add(total);
-        list.add(insertion);
-        list.add(deletion);
-        list.add(polymorphism);
         return list;
     }
-    
+
+    /**
+     * Return the maximum number of mutations in one of the stacks.
+     *
+     * @return the maximum number of mutations in one of the stacks.
+     */
     public Long getMaxMutations() {
-    	long max = 0;
-    	for (List<Long> stack : stackedMutations) {
-    		max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
-    	}
-    	return max;
+        long max = 0;
+        for (List<Long> stack : stackedMutations) {
+            max = Math.max(max, stack.get(1) + stack.get(2) + stack.get(3));
+        }
+        return max;
     }
 
     /**
@@ -215,11 +219,11 @@ public class StackedMutationContainer {
 
     }
 
-	/**
-	 * @return the level
-	 */
-	public int getLevel() {
-		return level;
-	}
+    /**
+     * @return the level
+     */
+    public int getLevel() {
+        return level;
+    }
 
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -56,7 +56,7 @@ public class StackedMutationContainer {
      */
     public StackedMutationContainer(final BucketCache buckets,
             final Set<Sequence> visibleSequences) {
-        this.level = (int) (Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
+        this.level = (int) Math.round(Math.log(buckets.getNumberBuckets()) / Math.log(2) + 1);
         fillStackedMutationContainer(this.level, buckets, visibleSequences);
     }
 
@@ -131,7 +131,7 @@ public class StackedMutationContainer {
      */
     private List<Long> insertStackedContainer(final List<Long> left,
             final List<Long> right) {
-        List<Long> stack = new ArrayList<>();
+        List<Long> stack = new ArrayList<>(left.size());
         for (int index = 0; index < left.size(); index++) {
             stack.add(left.get(index) + right.get(index));
         }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainer.java
@@ -183,8 +183,8 @@ public class StackedMutationContainer {
 
         Map<Mutation, Integer> mutations = new HashMap<>();
         mutations.put(Mutation.INSERTION, 1);
-        mutations.put(Mutation.DELETION, 1);
-        mutations.put(Mutation.POLYMORPHISM, 1);
+        mutations.put(Mutation.DELETION, 2);
+        mutations.put(Mutation.POLYMORPHISM, 3);
 
         for (SequenceSegment segment : bucket) {
             Set<Sequence> sources = new HashSet<>(segment.getSources());

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -15,33 +15,49 @@ import javafx.scene.Group;
  */
 public class DiagramView {
 
-    /**
-     * Draws the diagram view to the screen.
-     *
-     * @param container
-     *            The stacked mutation model which contains the data to display.
-     * @param zoomLevel
-     *            The zoom level of the graph controller used to determine the
-     *            stacked mutation container layer to display.
-     * @param width
-     *            The width of the diagram view based on the scale in the graph
-     *            controller.
-     * @return a group containing the stack views to draw.
-     */
-    public Group drawDiagram(final StackedMutationContainer container,
-            final int zoomLevel, final double width) {
-        Map<Integer, StackedMutationContainer> containers = container
-                .mapLevelStackedMutation();
-        Group root = new Group();
-        StackedMutationContainer stack = containers.get(Math.max(1,
-                Math.min(zoomLevel, container.getLevel() - 1)));
-        int stacks = stack.getStack().size();
-        for (int index = 0; index < stacks; index++) {
-            StackView stackView = new StackView(stack.getStack().get(index),
-                    (width / stacks), stack.getMaxMutations());
-            stackView.setLayoutX(index * width / stacks);
-            root.getChildren().add(stackView);
-        }
-        return root;
-    }
+	/**
+	 * Computes the stack level to display and draws the diagram view to the
+	 * screen.
+	 *
+	 * @param container
+	 *            The stacked mutation model which contains the data to display.
+	 * @param zoomLevel
+	 *            The zoom level of the graph controller used to determine the
+	 *            stacked mutation container layer to display.
+	 * @param width
+	 *            The width of the diagram view based on the scale in the graph
+	 *            controller.
+	 * @return a group containing the stack views to draw.
+	 */
+	public Group drawDiagram(final StackedMutationContainer container,
+			final int zoomLevel, final double width) {
+		Map<Integer, StackedMutationContainer> containers = container
+				.mapLevelStackedMutation();
+		int stackLevel = Math.max(1,
+				Math.min(zoomLevel, container.getLevel() - 1));
+		StackedMutationContainer stack = containers.get(stackLevel);
+		return drawStackContainer(stack, width);
+	}
+
+	/**
+	 * Displays the stacks in the diagram view.
+	 * 
+	 * @param stack
+	 *            The stack layer to display.
+	 * @param width
+	 *            The width of the stacks.
+	 * @return group with diagram containing a set of stack views.
+	 */
+	private Group drawStackContainer(final StackedMutationContainer stack,
+			final double width) {
+		Group root = new Group();
+		int stacks = stack.getStack().size();
+		for (int index = 0; index < stacks; index++) {
+			StackView stackView = new StackView(stack.getStack().get(index),
+					width / stacks, stack.getMaxMutations());
+			stackView.setLayoutX(index * width / stacks);
+			root.getChildren().add(stackView);
+		}
+		return root;
+	}
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -15,49 +15,49 @@ import javafx.scene.Group;
  */
 public class DiagramView {
 
-	/**
-	 * Computes the stack level to display and draws the diagram view to the
-	 * screen.
-	 *
-	 * @param container
-	 *            The stacked mutation model which contains the data to display.
-	 * @param zoomLevel
-	 *            The zoom level of the graph controller used to determine the
-	 *            stacked mutation container layer to display.
-	 * @param width
-	 *            The width of the diagram view based on the scale in the graph
-	 *            controller.
-	 * @return a group containing the stack views to draw.
-	 */
-	public Group drawDiagram(final StackedMutationContainer container,
-			final int zoomLevel, final double width) {
-		Map<Integer, StackedMutationContainer> containers = container
-				.mapLevelStackedMutation();
-		int stackLevel = Math.max(1,
-				Math.min(zoomLevel, container.getLevel() - 1));
-		StackedMutationContainer stack = containers.get(stackLevel);
-		return drawStackContainer(stack, width);
-	}
+    /**
+     * Computes the stack level to display and draws the diagram view to the
+     * screen.
+     *
+     * @param container
+     *            The stacked mutation model which contains the data to display.
+     * @param zoomLevel
+     *            The zoom level of the graph controller used to determine the
+     *            stacked mutation container layer to display.
+     * @param width
+     *            The width of the diagram view based on the scale in the graph
+     *            controller.
+     * @return a group containing the stack views to draw.
+     */
+    public Group drawDiagram(final StackedMutationContainer container,
+            final int zoomLevel, final double width) {
+        Map<Integer, StackedMutationContainer> containers = container
+                .mapLevelStackedMutation();
+        int stackLevel = Math.max(1,
+                Math.min(zoomLevel, container.getLevel() - 1));
+        StackedMutationContainer stack = containers.get(stackLevel);
+        return drawStackContainer(stack, width);
+    }
 
-	/**
-	 * Displays the stacks in the diagram view.
-	 * 
-	 * @param stack
-	 *            The stack layer to display.
-	 * @param width
-	 *            The width of the stacks.
-	 * @return group with diagram containing a set of stack views.
-	 */
-	private Group drawStackContainer(final StackedMutationContainer stack,
-			final double width) {
-		Group root = new Group();
-		int stacks = stack.getStack().size();
-		for (int index = 0; index < stacks; index++) {
-			StackView stackView = new StackView(stack.getStack().get(index),
-					width / stacks, stack.getMaxMutations());
-			stackView.setLayoutX(index * width / stacks);
-			root.getChildren().add(stackView);
-		}
-		return root;
-	}
+    /**
+     * Displays the stacks in the diagram view.
+     *
+     * @param stack
+     *            The stack layer to display.
+     * @param width
+     *            The width of the stacks.
+     * @return group with diagram containing a set of stack views.
+     */
+    private Group drawStackContainer(final StackedMutationContainer stack,
+            final double width) {
+        Group root = new Group();
+        int stacks = stack.getStack().size();
+        for (int index = 0; index < stacks; index++) {
+            StackView stackView = new StackView(stack.getStack().get(index),
+                    width / stacks, stack.getMaxMutations());
+            stackView.setLayoutX(index * width / stacks);
+            root.getChildren().add(stackView);
+        }
+        return root;
+    }
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -1,0 +1,66 @@
+package nl.tudelft.lifetiles.graph.view;
+
+import javafx.application.Application;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map;
+
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.stage.Stage;
+import nl.tudelft.lifetiles.graph.controller.GraphController;
+import nl.tudelft.lifetiles.graph.model.BucketCache;
+import nl.tudelft.lifetiles.graph.model.DefaultGraphParser;
+import nl.tudelft.lifetiles.graph.model.FactoryProducer;
+import nl.tudelft.lifetiles.graph.model.Graph;
+import nl.tudelft.lifetiles.graph.model.GraphFactory;
+import nl.tudelft.lifetiles.graph.model.StackedMutationContainer;
+import nl.tudelft.lifetiles.graph.traverser.EmptySegmentTraverser;
+import nl.tudelft.lifetiles.graph.traverser.MutationIndicationTraverser;
+import nl.tudelft.lifetiles.graph.traverser.ReferencePositionTraverser;
+import nl.tudelft.lifetiles.graph.traverser.UnifiedPositionTraverser;
+import nl.tudelft.lifetiles.sequence.model.Sequence;
+import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+
+/**
+ * Diagram view which contains a view of the stacked mutation diagram, which is
+ * a stacked representation of the percentage of mutations in a bucket or a
+ * merged bucket.
+ * 
+ * @author Jos
+ *
+ */
+public class DiagramView {
+
+    
+    static final double SPACING = 2;
+	/**
+	 * Controller which holds the graph.
+	 */
+	private GraphController controller;
+	private Map<Integer, StackedMutationContainer> containers;
+	private int zoomLevel;
+	
+	/**
+	 * Draws the diagram view to the screen.
+	 * 
+	 * @param container
+	 * @param zoomLevel
+	 * @return
+	 */
+	public Group drawDiagram(StackedMutationContainer container, int zoomLevel) {
+		containers = container.mapLevelStackedMutation();
+		Group root = new Group();
+
+		int scale = 4;
+		StackedMutationContainer stack = containers.get(scale);
+		for (int index = 0; index < stack.getStack().size(); index++) {
+			StackView stackView = new StackView(stack.getStack().get(index), zoomLevel, stack.getMaxMutations());
+			stackView.setLayoutX((index * (SPACING * zoomLevel + StackView.HORIZONTAL_SCALE * zoomLevel)));
+			root.getChildren().add(stackView);
+		}
+		return root;
+	}
+}

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -34,7 +34,7 @@ public class DiagramView {
         Map<Integer, StackedMutationContainer> containers = container
                 .mapLevelStackedMutation();
         int stackLevel = Math.max(1,
-                Math.min(zoomLevel, container.getLevel() - 1));
+                Math.min(zoomLevel, container.getLevel()));
         StackedMutationContainer stack = containers.get(stackLevel);
         return drawStackContainer(stack, width);
     }
@@ -52,10 +52,11 @@ public class DiagramView {
             final double width) {
         Group root = new Group();
         int stacks = stack.getStack().size();
+        double stackWidth = width / stacks;
         for (int index = 0; index < stacks; index++) {
             StackView stackView = new StackView(stack.getStack().get(index),
-                    width / stacks, stack.getMaxMutations());
-            stackView.setLayoutX(index * width / stacks);
+                    stackWidth, stack.getMaxMutations());
+            stackView.setLayoutX(index * stackWidth);
             root.getChildren().add(stackView);
         }
         return root;

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -1,66 +1,47 @@
 package nl.tudelft.lifetiles.graph.view;
 
-import javafx.application.Application;
-
-import java.io.File;
-import java.util.Iterator;
 import java.util.Map;
 
-import javafx.scene.Group;
-import javafx.scene.Scene;
-import javafx.scene.control.ScrollPane;
-import javafx.stage.Stage;
-import nl.tudelft.lifetiles.graph.controller.GraphController;
-import nl.tudelft.lifetiles.graph.model.BucketCache;
-import nl.tudelft.lifetiles.graph.model.DefaultGraphParser;
-import nl.tudelft.lifetiles.graph.model.FactoryProducer;
-import nl.tudelft.lifetiles.graph.model.Graph;
-import nl.tudelft.lifetiles.graph.model.GraphFactory;
 import nl.tudelft.lifetiles.graph.model.StackedMutationContainer;
-import nl.tudelft.lifetiles.graph.traverser.EmptySegmentTraverser;
-import nl.tudelft.lifetiles.graph.traverser.MutationIndicationTraverser;
-import nl.tudelft.lifetiles.graph.traverser.ReferencePositionTraverser;
-import nl.tudelft.lifetiles.graph.traverser.UnifiedPositionTraverser;
-import nl.tudelft.lifetiles.sequence.model.Sequence;
-import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+import javafx.scene.Group;
 
 /**
  * Diagram view which contains a view of the stacked mutation diagram, which is
  * a stacked representation of the percentage of mutations in a bucket or a
  * merged bucket.
- * 
+ *
  * @author Jos
  *
  */
 public class DiagramView {
 
-    
-    static final double SPACING = 2;
-	/**
-	 * Controller which holds the graph.
-	 */
-	private GraphController controller;
-	private Map<Integer, StackedMutationContainer> containers;
-	private int zoomLevel;
-	
-	/**
-	 * Draws the diagram view to the screen.
-	 * 
-	 * @param container
-	 * @param zoomLevel
-	 * @return
-	 */
-	public Group drawDiagram(StackedMutationContainer container, int zoomLevel) {
-		containers = container.mapLevelStackedMutation();
-		Group root = new Group();
-
-		int scale = 4;
-		StackedMutationContainer stack = containers.get(scale);
-		for (int index = 0; index < stack.getStack().size(); index++) {
-			StackView stackView = new StackView(stack.getStack().get(index), zoomLevel, stack.getMaxMutations());
-			stackView.setLayoutX((index * (SPACING * zoomLevel + StackView.HORIZONTAL_SCALE * zoomLevel)));
-			root.getChildren().add(stackView);
-		}
-		return root;
-	}
+    /**
+     * Draws the diagram view to the screen.
+     *
+     * @param container
+     *            The stacked mutation model which contains the data to display.
+     * @param zoomLevel
+     *            The zoom level of the graph controller used to determine the
+     *            stacked mutation container layer to display.
+     * @param width
+     *            The width of the diagram view based on the scale in the graph
+     *            controller.
+     * @return a group containing the stack views to draw.
+     */
+    public Group drawDiagram(final StackedMutationContainer container,
+            final int zoomLevel, final double width) {
+        Map<Integer, StackedMutationContainer> containers = container
+                .mapLevelStackedMutation();
+        Group root = new Group();
+        StackedMutationContainer stack = containers.get(Math.max(1,
+                Math.min(zoomLevel, container.getLevel() - 1)));
+        int stacks = stack.getStack().size();
+        for (int index = 0; index < stacks; index++) {
+            StackView stackView = new StackView(stack.getStack().get(index),
+                    (width / stacks), stack.getMaxMutations());
+            stackView.setLayoutX(index * (width / stacks));
+            root.getChildren().add(stackView);
+        }
+        return root;
+    }
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/DiagramView.java
@@ -39,7 +39,7 @@ public class DiagramView {
         for (int index = 0; index < stacks; index++) {
             StackView stackView = new StackView(stack.getStack().get(index),
                     (width / stacks), stack.getMaxMutations());
-            stackView.setLayoutX(index * (width / stacks));
+            stackView.setLayoutX(index * width / stacks);
             root.getChildren().add(stackView);
         }
         return root;

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
@@ -1,0 +1,76 @@
+package nl.tudelft.lifetiles.graph.view;
+
+import java.util.List;
+
+import nl.tudelft.lifetiles.core.util.ColorUtils;
+import nl.tudelft.lifetiles.sequence.Mutation;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+/**
+ * Stack view class which contains a single stacked column of the diagram view.
+ * Contains several rectangles proportional to the percentage of mutations in
+ * the bucket.
+ * 
+ * @author Jos
+ *
+ */
+public class StackView extends Group {
+    /**
+     * Default color of a tile element.
+     */
+    private static Color defaultColor = Color.web("a1d3ff");
+    /**
+     * Vertical scale of the StackView.
+     */
+    private static final double VERTICAL_SCALE = 300;
+    /**
+     * Horizontal scale of the StackView.
+     */
+    static final double HORIZONTAL_SCALE = 50;
+
+    /**
+     * Constructs a stack view, which contains a single stacked column of the
+     * diagram view.
+     * 
+     * @param quantities
+     *            List with quantities of the total vertices and mutations.
+     * @param zoomLevel 
+     * @param max 
+     */
+    StackView(List<Long> quantities, double zoomLevel, Long max) {
+        Rectangle reference = new Rectangle();
+        reference.setHeight(VERTICAL_SCALE);
+        reference.setWidth(HORIZONTAL_SCALE * zoomLevel);
+        reference.setStyle("-fx-fill:" + ColorUtils.webCode(defaultColor));
+
+        Rectangle insertion = new Rectangle();
+        insertion.setHeight(VERTICAL_SCALE * quantities.get(1)
+                / max);
+        insertion.setWidth(HORIZONTAL_SCALE * zoomLevel);
+        insertion.setStyle("-fx-fill:"
+                + ColorUtils.webCode(Mutation.INSERTION.getColor()));
+
+        Rectangle deletion = new Rectangle();
+        deletion.setLayoutY(insertion.getHeight());
+        deletion.setHeight(VERTICAL_SCALE * quantities.get(2)
+                / max);
+        deletion.setWidth(HORIZONTAL_SCALE * zoomLevel);
+        deletion.setStyle("-fx-fill:"
+                + ColorUtils.webCode(Mutation.DELETION.getColor()));
+
+        Rectangle polymorphism = new Rectangle();
+        polymorphism.setLayoutY(insertion.getHeight() + deletion.getHeight());
+        polymorphism.setHeight(VERTICAL_SCALE * quantities.get(3)
+                / max);
+        polymorphism.setWidth(HORIZONTAL_SCALE * zoomLevel);
+        polymorphism.setStyle("-fx-fill:"
+                + ColorUtils.webCode(Mutation.POLYMORPHISM.getColor()));
+
+        Group bars = new Group();
+        getChildren().addAll(reference, insertion, deletion, polymorphism);
+    }
+
+}

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
@@ -5,7 +5,6 @@ import java.util.List;
 import nl.tudelft.lifetiles.core.util.ColorUtils;
 import nl.tudelft.lifetiles.sequence.Mutation;
 import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 
@@ -13,7 +12,7 @@ import javafx.scene.shape.Rectangle;
  * Stack view class which contains a single stacked column of the diagram view.
  * Contains several rectangles proportional to the percentage of mutations in
  * the bucket.
- * 
+ *
  * @author Jos
  *
  */
@@ -30,46 +29,59 @@ public class StackView extends Group {
      * Horizontal scale of the StackView.
      */
     static final double HORIZONTAL_SCALE = 50;
+    /**
+     * Scale used to create the spacing between the different stack views in the
+     * diagram view.
+     */
+    private static final double SPACING_SCALE = 0.85;
+
+    /**
+     * String used to assign the style field for the background color of the
+     * rectangle.
+     */
+    private static final String FX_FILL = "-fx-fill:";
 
     /**
      * Constructs a stack view, which contains a single stacked column of the
      * diagram view.
-     * 
+     *
      * @param quantities
      *            List with quantities of the total vertices and mutations.
-     * @param zoomLevel 
-     * @param max 
+     * @param width
+     *            Width of this stack view based on the zoom level of the graph
+     *            controller.
+     * @param max
+     *            The maximal scale of the quantity percentage, we just want to
+     *            see the interesting information.
      */
-    StackView(List<Long> quantities, double zoomLevel, Long max) {
+    StackView(final List<Long> quantities, final double width, final Long max) {
+        double rectangleWidth = width * SPACING_SCALE;
+
         Rectangle reference = new Rectangle();
         reference.setHeight(VERTICAL_SCALE);
-        reference.setWidth(HORIZONTAL_SCALE * zoomLevel);
-        reference.setStyle("-fx-fill:" + ColorUtils.webCode(defaultColor));
+        reference.setWidth(rectangleWidth);
+        reference.setStyle(FX_FILL + ColorUtils.webCode(defaultColor));
 
         Rectangle insertion = new Rectangle();
-        insertion.setHeight(VERTICAL_SCALE * quantities.get(1)
-                / max);
-        insertion.setWidth(HORIZONTAL_SCALE * zoomLevel);
-        insertion.setStyle("-fx-fill:"
+        insertion.setHeight(VERTICAL_SCALE * quantities.get(1) / max);
+        insertion.setWidth(rectangleWidth);
+        insertion.setStyle(FX_FILL
                 + ColorUtils.webCode(Mutation.INSERTION.getColor()));
 
         Rectangle deletion = new Rectangle();
         deletion.setLayoutY(insertion.getHeight());
-        deletion.setHeight(VERTICAL_SCALE * quantities.get(2)
-                / max);
-        deletion.setWidth(HORIZONTAL_SCALE * zoomLevel);
-        deletion.setStyle("-fx-fill:"
+        deletion.setHeight(VERTICAL_SCALE * quantities.get(2) / max);
+        deletion.setWidth(rectangleWidth);
+        deletion.setStyle(FX_FILL
                 + ColorUtils.webCode(Mutation.DELETION.getColor()));
 
         Rectangle polymorphism = new Rectangle();
         polymorphism.setLayoutY(insertion.getHeight() + deletion.getHeight());
-        polymorphism.setHeight(VERTICAL_SCALE * quantities.get(3)
-                / max);
-        polymorphism.setWidth(HORIZONTAL_SCALE * zoomLevel);
-        polymorphism.setStyle("-fx-fill:"
+        polymorphism.setHeight(VERTICAL_SCALE * quantities.get(3) / max);
+        polymorphism.setWidth(rectangleWidth);
+        polymorphism.setStyle(FX_FILL
                 + ColorUtils.webCode(Mutation.POLYMORPHISM.getColor()));
 
-        Group bars = new Group();
         getChildren().addAll(reference, insertion, deletion, polymorphism);
     }
 

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
@@ -1,11 +1,12 @@
 package nl.tudelft.lifetiles.graph.view;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import nl.tudelft.lifetiles.core.util.ColorUtils;
 import nl.tudelft.lifetiles.sequence.Mutation;
 import javafx.scene.Group;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.shape.Rectangle;
 
 /**
@@ -17,72 +18,78 @@ import javafx.scene.shape.Rectangle;
  *
  */
 public class StackView extends Group {
-    /**
-     * Default color of a tile element.
-     */
-    private static Color defaultColor = Color.web("a1d3ff");
-    /**
-     * Vertical scale of the StackView.
-     */
-    private static final double VERTICAL_SCALE = 300;
-    /**
-     * Horizontal scale of the StackView.
-     */
-    static final double HORIZONTAL_SCALE = 50;
-    /**
-     * Scale used to create the spacing between the different stack views in the
-     * diagram view.
-     */
-    private static final double SPACING_SCALE = 0.85;
+	/**
+	 * Default color of a tile element.
+	 */
+	private static Color defaultColor = Color.web("a1d3ff");
+	/**
+	 * Vertical scale of the StackView.
+	 */
+	private static final double VERTICAL_SCALE = 300;
+	/**
+	 * Horizontal scale of the StackView.
+	 */
+	static final double HORIZONTAL_SCALE = 50;
+	/**
+	 * Scale used to create the spacing between the different stack views in the
+	 * diagram view.
+	 */
+	private static final double SPACING_SCALE = 0.85;
+	/**
+	 * Width of the rectangle.
+	 */
+	private double rectangleWidth;
 
-    /**
-     * String used to assign the style field for the background color of the
-     * rectangle.
-     */
-    private static final String FX_FILL = "-fx-fill:";
+	/**
+	 * Constructs a stack view, which contains a single stacked column of the
+	 * diagram view.
+	 *
+	 * @param quantities
+	 *            List with quantities of the total vertices and mutations.
+	 * @param width
+	 *            Width of this stack view based on the zoom level of the graph
+	 *            controller.
+	 * @param max
+	 *            The maximal scale of the quantity percentage, we just want to
+	 *            see the interesting information.
+	 */
+	StackView(final List<Long> quantities, final double width, final Long max) {
+		rectangleWidth = width * SPACING_SCALE;
 
-    /**
-     * Constructs a stack view, which contains a single stacked column of the
-     * diagram view.
-     *
-     * @param quantities
-     *            List with quantities of the total vertices and mutations.
-     * @param width
-     *            Width of this stack view based on the zoom level of the graph
-     *            controller.
-     * @param max
-     *            The maximal scale of the quantity percentage, we just want to
-     *            see the interesting information.
-     */
-    StackView(final List<Long> quantities, final double width, final Long max) {
-        double rectangleWidth = width * SPACING_SCALE;
+		getChildren().add(drawPart(VERTICAL_SCALE, 0.0, defaultColor));
 
-        Rectangle reference = new Rectangle();
-        reference.setHeight(VERTICAL_SCALE);
-        reference.setWidth(rectangleWidth);
-        reference.setStyle(FX_FILL + ColorUtils.webCode(defaultColor));
+		List<Paint> colors = new ArrayList<>();
+		colors.add(Mutation.INSERTION.getColor());
+		colors.add(Mutation.DELETION.getColor());
+		colors.add(Mutation.POLYMORPHISM.getColor());
 
-        Rectangle insertion = new Rectangle();
-        insertion.setHeight(VERTICAL_SCALE * quantities.get(1) / max);
-        insertion.setWidth(rectangleWidth);
-        insertion.setStyle(FX_FILL
-                + ColorUtils.webCode(Mutation.INSERTION.getColor()));
+		double offset = 0.0;
+		for (int index = 1; index <= 3; index++) {
+			double height = VERTICAL_SCALE * quantities.get(index) / max;
+			getChildren().add(drawPart(height, offset, colors.get(index - 1)));
+			offset += height;
+		}
+	}
 
-        Rectangle deletion = new Rectangle();
-        deletion.setLayoutY(insertion.getHeight());
-        deletion.setHeight(VERTICAL_SCALE * quantities.get(2) / max);
-        deletion.setWidth(rectangleWidth);
-        deletion.setStyle(FX_FILL
-                + ColorUtils.webCode(Mutation.DELETION.getColor()));
-
-        Rectangle polymorphism = new Rectangle();
-        polymorphism.setLayoutY(insertion.getHeight() + deletion.getHeight());
-        polymorphism.setHeight(VERTICAL_SCALE * quantities.get(3) / max);
-        polymorphism.setWidth(rectangleWidth);
-        polymorphism.setStyle(FX_FILL
-                + ColorUtils.webCode(Mutation.POLYMORPHISM.getColor()));
-
-        getChildren().addAll(reference, insertion, deletion, polymorphism);
-    }
+	/**
+	 * Paints a single part of the stack view.
+	 * 
+	 * @param height
+	 *            Height of the stack part.
+	 * @param offset
+	 *            Offset of the stack part.
+	 * @param paint
+	 *            Color of the stack part.
+	 * @return rectangle presentation of the stack part.
+	 */
+	private Rectangle drawPart(final double height, final double offset,
+			final Paint paint) {
+		Rectangle rectangle = new Rectangle();
+		rectangle.setLayoutY(offset);
+		rectangle.setHeight(height);
+		rectangle.setWidth(rectangleWidth);
+		rectangle.setFill(paint);
+		return rectangle;
+	}
 
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
@@ -18,78 +18,78 @@ import javafx.scene.shape.Rectangle;
  *
  */
 public class StackView extends Group {
-	/**
-	 * Default color of a tile element.
-	 */
-	private static Color defaultColor = Color.web("a1d3ff");
-	/**
-	 * Vertical scale of the StackView.
-	 */
-	private static final double VERTICAL_SCALE = 300;
-	/**
-	 * Horizontal scale of the StackView.
-	 */
-	static final double HORIZONTAL_SCALE = 50;
-	/**
-	 * Scale used to create the spacing between the different stack views in the
-	 * diagram view.
-	 */
-	private static final double SPACING_SCALE = 0.85;
-	/**
-	 * Width of the rectangle.
-	 */
-	private double rectangleWidth;
+    /**
+     * Default color of a tile element.
+     */
+    private static Color defaultColor = Color.web("a1d3ff");
+    /**
+     * Vertical scale of the StackView.
+     */
+    private static final double VERTICAL_SCALE = 300;
+    /**
+     * Horizontal scale of the StackView.
+     */
+    static final double HORIZONTAL_SCALE = 50;
+    /**
+     * Scale used to create the spacing between the different stack views in the
+     * diagram view.
+     */
+    private static final double SPACING_SCALE = 0.85;
+    /**
+     * Width of the rectangle.
+     */
+    private double rectangleWidth;
 
-	/**
-	 * Constructs a stack view, which contains a single stacked column of the
-	 * diagram view.
-	 *
-	 * @param quantities
-	 *            List with quantities of the total vertices and mutations.
-	 * @param width
-	 *            Width of this stack view based on the zoom level of the graph
-	 *            controller.
-	 * @param max
-	 *            The maximal scale of the quantity percentage, we just want to
-	 *            see the interesting information.
-	 */
-	StackView(final List<Long> quantities, final double width, final Long max) {
-		rectangleWidth = width * SPACING_SCALE;
+    /**
+     * Constructs a stack view, which contains a single stacked column of the
+     * diagram view.
+     *
+     * @param quantities
+     *            List with quantities of the total vertices and mutations.
+     * @param width
+     *            Width of this stack view based on the zoom level of the graph
+     *            controller.
+     * @param max
+     *            The maximal scale of the quantity percentage, we just want to
+     *            see the interesting information.
+     */
+    StackView(final List<Long> quantities, final double width, final Long max) {
+        rectangleWidth = width * SPACING_SCALE;
 
-		getChildren().add(drawPart(VERTICAL_SCALE, 0.0, defaultColor));
+        getChildren().add(drawPart(VERTICAL_SCALE, 0.0, defaultColor));
 
-		List<Paint> colors = new ArrayList<>();
-		colors.add(Mutation.INSERTION.getColor());
-		colors.add(Mutation.DELETION.getColor());
-		colors.add(Mutation.POLYMORPHISM.getColor());
+        List<Paint> colors = new ArrayList<>();
+        colors.add(Mutation.INSERTION.getColor());
+        colors.add(Mutation.DELETION.getColor());
+        colors.add(Mutation.POLYMORPHISM.getColor());
 
-		double offset = 0.0;
-		for (int index = 1; index <= 3; index++) {
-			double height = VERTICAL_SCALE * quantities.get(index) / max;
-			getChildren().add(drawPart(height, offset, colors.get(index - 1)));
-			offset += height;
-		}
-	}
+        double offset = 0.0;
+        for (int index = 1; index <= 3; index++) {
+            double height = VERTICAL_SCALE * quantities.get(index) / max;
+            getChildren().add(drawPart(height, offset, colors.get(index - 1)));
+            offset += height;
+        }
+    }
 
-	/**
-	 * Paints a single part of the stack view.
-	 * 
-	 * @param height
-	 *            Height of the stack part.
-	 * @param offset
-	 *            Offset of the stack part.
-	 * @param paint
-	 *            Color of the stack part.
-	 * @return rectangle presentation of the stack part.
-	 */
-	private Rectangle drawPart(final double height, final double offset,
-			final Paint paint) {
-		Rectangle rectangle = new Rectangle();
-		rectangle.setLayoutY(offset);
-		rectangle.setHeight(height);
-		rectangle.setWidth(rectangleWidth);
-		rectangle.setFill(paint);
-		return rectangle;
-	}
+    /**
+     * Paints a single part of the stack view.
+     *
+     * @param height
+     *            Height of the stack part.
+     * @param offset
+     *            Offset of the stack part.
+     * @param paint
+     *            Color of the stack part.
+     * @return rectangle presentation of the stack part.
+     */
+    private Rectangle drawPart(final double height, final double offset,
+            final Paint paint) {
+        Rectangle rectangle = new Rectangle();
+        rectangle.setLayoutY(offset);
+        rectangle.setHeight(height);
+        rectangle.setWidth(rectangleWidth);
+        rectangle.setFill(paint);
+        return rectangle;
+    }
 
 }

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/StackView.java
@@ -1,6 +1,6 @@
 package nl.tudelft.lifetiles.graph.view;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import nl.tudelft.lifetiles.sequence.Mutation;
@@ -38,7 +38,7 @@ public class StackView extends Group {
     /**
      * Width of the rectangle.
      */
-    private double rectangleWidth;
+    private final double rectangleWidth;
 
     /**
      * Constructs a stack view, which contains a single stacked column of the
@@ -58,10 +58,8 @@ public class StackView extends Group {
 
         getChildren().add(drawPart(VERTICAL_SCALE, 0.0, defaultColor));
 
-        List<Paint> colors = new ArrayList<>();
-        colors.add(Mutation.INSERTION.getColor());
-        colors.add(Mutation.DELETION.getColor());
-        colors.add(Mutation.POLYMORPHISM.getColor());
+        List<Paint> colors = Arrays.asList(Mutation.INSERTION.getColor(),
+                Mutation.DELETION.getColor(), Mutation.POLYMORPHISM.getColor());
 
         double offset = 0.0;
         for (int index = 1; index <= 3; index++) {

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/controller/ZoombarTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/controller/ZoombarTest.java
@@ -17,7 +17,7 @@ public class ZoombarTest {
     public void clickOnPlus() {
         // Hack because javafx toolkit need to be initialized
         JFXPanel panel = new JFXPanel();
-        Zoombar toolbar = new Zoombar(10);
+        Zoombar toolbar = new Zoombar(5, 10);
 
         ToolBar javafxBar = toolbar.getToolBar();
         int initZoom = toolbar.getZoomlevel().intValue();
@@ -35,7 +35,7 @@ public class ZoombarTest {
     public void clickOnMinus() {
         // Hack because javafx toolkit need to be initialized
         JFXPanel panel = new JFXPanel();
-        Zoombar toolbar = new Zoombar(10);
+        Zoombar toolbar = new Zoombar(5, 10);
 
         ToolBar javafxBar = toolbar.getToolBar();
         int initZoom = toolbar.getZoomlevel().intValue();
@@ -53,7 +53,7 @@ public class ZoombarTest {
     public void scrolloneUpSlider() {
         // Hack because javafx toolkit need to be initialized
         JFXPanel panel = new JFXPanel();
-        Zoombar toolbar = new Zoombar(10);
+        Zoombar toolbar = new Zoombar(5, 10);
 
         ToolBar javafxBar = toolbar.getToolBar();
         int initZoom = toolbar.getZoomlevel().intValue();
@@ -69,7 +69,7 @@ public class ZoombarTest {
     public void scrolloneDownSlider() {
         // Hack because javafx toolkit need to be initialized
         JFXPanel panel = new JFXPanel();
-        Zoombar toolbar = new Zoombar(10);
+        Zoombar toolbar = new Zoombar(5, 10);
 
         ToolBar javafxBar = toolbar.getToolBar();
         int initZoom = toolbar.getZoomlevel().intValue();

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/BucketCacheTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/BucketCacheTest.java
@@ -3,10 +3,12 @@ package nl.tudelft.lifetiles.graph.model;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import nl.tudelft.lifetiles.graph.model.FactoryProducer;
 import nl.tudelft.lifetiles.graph.model.Graph;
 import nl.tudelft.lifetiles.graph.model.GraphFactory;
+import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
 import nl.tudelft.lifetiles.sequence.model.SegmentEmpty;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
@@ -24,12 +26,14 @@ public class BucketCacheTest {
         gf = FactoryProducer.getFactory("JGraphT");
         gr = gf.getGraph();
 
-        v1 = new SequenceSegment(new HashSet<Sequence>(), 1, 11,
+        Set<Sequence> s  = new HashSet<Sequence>();
+        s.add(new DefaultSequence("reference"));
+        v1 = new SequenceSegment(s, 1, 11,
                 new SegmentEmpty(10));
         v1.setUnifiedStart(1);
         v1.setUnifiedEnd(11);
 
-        v2 = new SequenceSegment(new HashSet<Sequence>(), 31, 41,
+        v2 = new SequenceSegment(s, 31, 41,
                 new SegmentEmpty(10));
         v2.setUnifiedStart(31);
         v2.setUnifiedEnd(41);

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/BucketCacheTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/BucketCacheTest.java
@@ -41,6 +41,7 @@ public class BucketCacheTest {
         gr.addVertex(v2);
         gr.addEdge(v1, v2);
         BucketCache bc = new BucketCache(1, gr);
+        assertEquals(1, bc.getNumberBuckets());
         assertEquals(2, bc.getBuckets().get(0).size());
     }
 
@@ -50,6 +51,7 @@ public class BucketCacheTest {
         gr.addVertex(v2);
         gr.addEdge(v1, v2);
         BucketCache bc = new BucketCache(2, gr);
+        assertEquals(2, bc.getNumberBuckets());
         assertEquals(1, bc.getBuckets().get(0).size());
         assertEquals(1, bc.getBuckets().get(1).size());
     }

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
@@ -3,9 +3,7 @@ package nl.tudelft.lifetiles.graph.model;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
@@ -43,7 +41,7 @@ public class StackedMutationContainerTest {
     @Test
     public void exampleContentBucketTest() {
         BucketCache b = new BucketCache(8, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         assertEquals(8, s.mapLevelStackedMutation().get(1).getStack().size());
         assertEquals(4, s.mapLevelStackedMutation().get(2).getStack().size());
         assertEquals(2, s.mapLevelStackedMutation().get(3).getStack().size());
@@ -55,7 +53,7 @@ public class StackedMutationContainerTest {
     public void singleBucketSingleContentTest() {
         gr.addVertex(v1);
         BucketCache b = new BucketCache(1, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         ArrayList<Long> stack = new ArrayList<Long>();
         stack.add((long) 10);
         stack.add((long) 0);
@@ -69,7 +67,7 @@ public class StackedMutationContainerTest {
         gr.addVertex(v1);
         gr.addVertex(v2);
         BucketCache b = new BucketCache(1, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         ArrayList<Long> stack = new ArrayList<Long>();
         stack.add((long) 20);
         stack.add((long) 0);
@@ -83,7 +81,7 @@ public class StackedMutationContainerTest {
         gr.addVertex(v1);
         gr.addVertex(v2);
         BucketCache b = new BucketCache(2, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
 
         ArrayList<Long> stack = new ArrayList<Long>();
         stack.add((long) 10);
@@ -108,7 +106,7 @@ public class StackedMutationContainerTest {
         gr.addVertex(v1);
         gr.addVertex(v2);
         BucketCache b = new BucketCache(1000, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
 
         ArrayList<Long> stack = new ArrayList<Long>();
         stack.add((long) 20);
@@ -121,21 +119,21 @@ public class StackedMutationContainerTest {
     @Test
     public void emptyBucketTest() {
         BucketCache b = new BucketCache(1, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         assertEquals(1, s.mapLevelStackedMutation().size());
     }
 
     @Test
     public void emptyDoubleBucketTest() {
         BucketCache b = new BucketCache(2, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         assertEquals(2, s.mapLevelStackedMutation().size());
     }
 
     @Test
     public void emptyMultipleBucketTest() {
         BucketCache b = new BucketCache(1024, gr);
-        StackedMutationContainer s = new StackedMutationContainer(b);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
         assertEquals(11, s.mapLevelStackedMutation().size());
     }
 

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
 import nl.tudelft.lifetiles.sequence.model.SegmentEmpty;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
@@ -24,12 +26,15 @@ public class StackedMutationContainerTest {
         gf = FactoryProducer.getFactory("JGraphT");
         gr = gf.getGraph();
 
-        v1 = new SequenceSegment(new HashSet<Sequence>(), 1, 11,
+        Set<Sequence> s  = new HashSet<Sequence>();
+        s.add(new DefaultSequence("reference"));
+
+        v1 = new SequenceSegment(s, 1, 11,
                 new SegmentEmpty(10));
         v1.setUnifiedStart(1);
         v1.setUnifiedEnd(11);
 
-        v2 = new SequenceSegment(new HashSet<Sequence>(), 31, 41,
+        v2 = new SequenceSegment(s, 31, 41,
                 new SegmentEmpty(10));
         v2.setUnifiedStart(31);
         v2.setUnifiedEnd(41);
@@ -106,7 +111,7 @@ public class StackedMutationContainerTest {
         StackedMutationContainer s = new StackedMutationContainer(b);
 
         ArrayList<Long> stack = new ArrayList<Long>();
-        stack.add((long) 220);
+        stack.add((long) 20);
         stack.add((long) 0);
         stack.add((long) 0);
         stack.add((long) 0);
@@ -128,7 +133,7 @@ public class StackedMutationContainerTest {
     }
 
     @Test
-    public void emptyMultipleleBucketTest() {
+    public void emptyMultipleBucketTest() {
         BucketCache b = new BucketCache(1024, gr);
         StackedMutationContainer s = new StackedMutationContainer(b);
         assertEquals(11, s.mapLevelStackedMutation().size());

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
@@ -1,0 +1,137 @@
+package nl.tudelft.lifetiles.graph.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import nl.tudelft.lifetiles.sequence.model.SegmentEmpty;
+import nl.tudelft.lifetiles.sequence.model.Sequence;
+import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class StackedMutationContainerTest {
+    GraphFactory<SequenceSegment> gf;
+    SequenceSegment v1, v2;
+    Graph<SequenceSegment> gr;
+
+    @Before
+    public void setUp() {
+        gf = FactoryProducer.getFactory("JGraphT");
+        gr = gf.getGraph();
+
+        v1 = new SequenceSegment(new HashSet<Sequence>(), 1, 11,
+                new SegmentEmpty(10));
+        v1.setUnifiedStart(1);
+        v1.setUnifiedEnd(11);
+
+        v2 = new SequenceSegment(new HashSet<Sequence>(), 31, 41,
+                new SegmentEmpty(10));
+        v2.setUnifiedStart(31);
+        v2.setUnifiedEnd(41);
+    }
+
+    @Test
+    public void exampleContentBucketTest() {
+        BucketCache b = new BucketCache(8, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        assertEquals(8, s.mapLevelStackedMutation().get(1).getStack().size());
+        assertEquals(4, s.mapLevelStackedMutation().get(2).getStack().size());
+        assertEquals(2, s.mapLevelStackedMutation().get(3).getStack().size());
+        assertEquals(1, s.mapLevelStackedMutation().get(4).getStack().size());
+        assertEquals(1, s.getStack().size());
+    }
+
+    @Test
+    public void singleBucketSingleContentTest() {
+        gr.addVertex(v1);
+        BucketCache b = new BucketCache(1, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 10);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        assertEquals(stack, s.getStack().get(0));
+    }
+
+    @Test
+    public void singleBucketMultipleContentTest() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        BucketCache b = new BucketCache(1, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 20);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        assertEquals(stack, s.getStack().get(0));
+    }
+
+    @Test
+    public void doubleBucketMultipleContentTest() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        BucketCache b = new BucketCache(2, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 10);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        assertEquals(stack, s.mapLevelStackedMutation().get(1).getStack()
+                .get(0));
+        assertEquals(stack, s.mapLevelStackedMutation().get(1).getStack()
+                .get(1));
+
+        stack = new ArrayList<Long>();
+        stack.add((long) 20);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        assertEquals(stack, s.getStack().get(0));
+    }
+
+    @Test
+    public void multipleBucketMultipleContentTest() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        BucketCache b = new BucketCache(1000, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 220);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        assertEquals(stack, s.getStack().get(0));
+    }
+
+    @Test
+    public void emptyBucketTest() {
+        BucketCache b = new BucketCache(1, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        assertEquals(1, s.mapLevelStackedMutation().size());
+    }
+
+    @Test
+    public void emptyDoubleBucketTest() {
+        BucketCache b = new BucketCache(2, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        assertEquals(2, s.mapLevelStackedMutation().size());
+    }
+
+    @Test
+    public void emptyMultipleleBucketTest() {
+        BucketCache b = new BucketCache(1024, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b);
+        assertEquals(11, s.mapLevelStackedMutation().size());
+    }
+
+}

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/model/StackedMutationContainerTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+import nl.tudelft.lifetiles.sequence.Mutation;
 import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
 import nl.tudelft.lifetiles.sequence.model.SegmentEmpty;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
@@ -65,12 +66,13 @@ public class StackedMutationContainerTest {
     @Test
     public void singleBucketMultipleContentTest() {
         gr.addVertex(v1);
+        v1.setMutation(Mutation.INSERTION);
         gr.addVertex(v2);
         BucketCache b = new BucketCache(1, gr);
         StackedMutationContainer s = new StackedMutationContainer(b, null);
         ArrayList<Long> stack = new ArrayList<Long>();
         stack.add((long) 20);
-        stack.add((long) 0);
+        stack.add((long) 10);
         stack.add((long) 0);
         stack.add((long) 0);
         assertEquals(stack, s.getStack().get(0));
@@ -135,6 +137,33 @@ public class StackedMutationContainerTest {
         BucketCache b = new BucketCache(1024, gr);
         StackedMutationContainer s = new StackedMutationContainer(b, null);
         assertEquals(11, s.mapLevelStackedMutation().size());
+    }
+    
+    @Test
+    public void maxMutationTest() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        BucketCache b = new BucketCache(1024, gr);
+        StackedMutationContainer s = new StackedMutationContainer(b, null);
+        assertEquals(0, s.getMaxMutations().longValue());
+    }
+    
+    @Test
+    public void invisibleBucketTest() {
+        gr.addVertex(v1);
+        gr.addVertex(v2);
+        BucketCache b = new BucketCache(1, gr);
+
+        Set<Sequence> set  = new HashSet<Sequence>();
+        set.add(new DefaultSequence("empty"));
+
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        stack.add((long) 0);
+        StackedMutationContainer s = new StackedMutationContainer(b, set);
+        assertEquals(stack, s.getStack().get(0));
     }
 
 }

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/view/DiagramViewTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/view/DiagramViewTest.java
@@ -1,0 +1,65 @@
+package nl.tudelft.lifetiles.graph.view;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import javafx.scene.Group;
+import nl.tudelft.lifetiles.graph.model.BucketCache;
+import nl.tudelft.lifetiles.graph.model.FactoryProducer;
+import nl.tudelft.lifetiles.graph.model.Graph;
+import nl.tudelft.lifetiles.graph.model.GraphFactory;
+import nl.tudelft.lifetiles.graph.model.StackedMutationContainer;
+import nl.tudelft.lifetiles.sequence.model.DefaultSequence;
+import nl.tudelft.lifetiles.sequence.model.SegmentEmpty;
+import nl.tudelft.lifetiles.sequence.model.Sequence;
+import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DiagramViewTest {
+    private Group diagram;
+    GraphFactory<SequenceSegment> gf;
+    SequenceSegment v1, v2;
+    Graph<SequenceSegment> gr;
+
+    @Before
+    public void setup() {
+        gf = FactoryProducer.getFactory("JGraphT");
+        gr = gf.getGraph();
+        
+        Set<Sequence> s  = new HashSet<Sequence>();
+        s.add(new DefaultSequence("reference"));
+        v1 = new SequenceSegment(s, 1, 11,
+                new SegmentEmpty(10));
+        v1.setUnifiedStart(1);
+        v1.setUnifiedEnd(11);
+        
+        v2 = new SequenceSegment(s, 31, 41,
+                new SegmentEmpty(10));
+        v2.setUnifiedStart(31);
+        v2.setUnifiedEnd(41);
+        
+        BucketCache b = new BucketCache(1000, gr);
+        StackedMutationContainer container = new StackedMutationContainer(b, null);
+        diagram = (new DiagramView()).drawDiagram(container, 1, 100);
+    }
+    
+    @Test 
+    public void childrenTest() {
+        assertEquals(1024, diagram.getChildren().size());
+    }
+
+    @Test
+    public void xLayoutTest() {
+        assertEquals(0, diagram.getLayoutX(), 1e-10);
+    }
+
+    @Test
+    public void yLayoutTest() {
+        assertEquals(0, diagram.getLayoutY(), 1e-10);
+    }
+}

--- a/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/view/StackViewTest.java
+++ b/lifetiles-graph/src/test/java/nl/tudelft/lifetiles/graph/view/StackViewTest.java
@@ -1,0 +1,39 @@
+package nl.tudelft.lifetiles.graph.view;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class StackViewTest {
+
+    private StackView s;
+
+    @Before
+    public void setup() {
+        ArrayList<Long> stack = new ArrayList<Long>();
+        stack.add((long) 10);
+        stack.add((long) 20);
+        stack.add((long) 30);
+        stack.add((long) 40);
+        s = new StackView(stack, 20, (long) 90);
+    }
+    
+    @Test 
+    public void childrenTest() {
+        assertEquals(4, s.getChildren().size());
+    }
+
+    @Test
+    public void xLayoutTest() {
+        assertEquals(0, s.getLayoutX(), 1e-10);
+    }
+
+    @Test
+    public void yLayoutTest() {
+        assertEquals(0, s.getLayoutY(), 1e-10);
+    }
+    
+}

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/controller/SequenceController.java
@@ -244,6 +244,7 @@ public final class SequenceController extends AbstractController {
                 sequenceEntry = SequenceEntry
                         .fromSequence(sequence, true, true);
                 reference = identifier;
+                shout(SequenceController.REFERENCE_SET, "", sequence);
             } else {
                 sequenceEntry = SequenceEntry.fromSequence(sequence);
             }


### PR DESCRIPTION
If you zoom out you see the graph divided in a diagram view. The balancing of the zoom levels will be done in another pull request.

For example if we would try to create a stacked mutation container with as number of buckets, 8, the following structure would be generated:

```
level 1: ▄ ▄ ▄ ▄ ▄ ▄ ▄ ▄
level 2: ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄
level 3: ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄
level 4: ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
```
