### PR TITLE
Horizontal collapsing of segments which contain all sequences

### DIFF
--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -407,8 +407,7 @@ public class GraphController extends AbstractController {
      * @param graph
      *            The graph to be collapsed.
      * @param sequences
-     *            The total amount of sequences used in the graph, used to
-     *            determine whether a node is total.
+     *            The amount of sequences in the graph.
      */
     private void collapseGraph(final Graph<SequenceSegment> graph,
             final int sequences) {

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -402,6 +402,7 @@ public class GraphController extends AbstractController {
 
     /**
      * Collapses the total segments in the graph.
+     * Total segments contain all sequences in the graph.
      *
      * @param graph
      *            The graph to be collapsed.

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/controller/GraphController.java
@@ -37,6 +37,7 @@ import nl.tudelft.lifetiles.graph.view.VertexView;
 import nl.tudelft.lifetiles.notification.controller.NotificationController;
 import nl.tudelft.lifetiles.notification.model.NotificationFactory;
 import nl.tudelft.lifetiles.sequence.controller.SequenceController;
+import nl.tudelft.lifetiles.sequence.model.SegmentStringCollapsed;
 import nl.tudelft.lifetiles.sequence.model.Sequence;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
@@ -367,6 +368,8 @@ public class GraphController extends AbstractController {
         GraphFactory<SequenceSegment> factory = FactoryProducer.getFactory();
         GraphParser parser = new DefaultGraphParser();
         graph = parser.parseGraph(vertexfile, edgefile, factory);
+
+        collapseGraph(graph, parser.getSequences().size());
         knownMutations = new HashMap<>();
         mappedAnnotations = new HashMap<>();
 
@@ -395,6 +398,25 @@ public class GraphController extends AbstractController {
         timer.stopAndLog("Inserting known mutations");
         repaintNow = true;
         repaintPosition(scrollPane.hvalueProperty().doubleValue());
+    }
+
+    /**
+     * Collapses the total segments in the graph.
+     *
+     * @param graph
+     *            The graph to be collapsed.
+     * @param sequences
+     *            The total amount of sequences used in the graph, used to
+     *            determine whether a node is total.
+     */
+    private void collapseGraph(final Graph<SequenceSegment> graph,
+            final int sequences) {
+        for (SequenceSegment segment : graph.getAllVertices()) {
+            if (segment.getSources().size() == sequences) {
+                segment.setContent(new SegmentStringCollapsed(segment
+                        .getContent()));
+            }
+        }
     }
 
     /**

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
@@ -15,7 +15,6 @@ import nl.tudelft.lifetiles.annotation.model.KnownMutation;
 import nl.tudelft.lifetiles.graph.controller.GraphController;
 import nl.tudelft.lifetiles.graph.model.Graph;
 import nl.tudelft.lifetiles.sequence.Mutation;
-import nl.tudelft.lifetiles.sequence.model.SegmentStringCollapsed;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
 /**

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
@@ -214,13 +214,7 @@ public class TileView {
         long width = segment.getContent().getLength();
         long height = segment.getSources().size();
 
-        Color color;
-        if (segment.getContent() instanceof SegmentStringCollapsed) {
-            color = Color.DARKGRAY;
-        } else {
-            color = sequenceColor(segment.getMutation());
-        }
-
+        Color color = sequenceColor(segment.getMutation());
         Point2D topleft = new Point2D(start, index);
 
         VertexView vertex = new VertexView(text, topleft, width, height, scale,

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
@@ -15,6 +15,7 @@ import nl.tudelft.lifetiles.annotation.model.KnownMutation;
 import nl.tudelft.lifetiles.graph.controller.GraphController;
 import nl.tudelft.lifetiles.graph.model.Graph;
 import nl.tudelft.lifetiles.sequence.Mutation;
+import nl.tudelft.lifetiles.sequence.model.SegmentStringCollapsed;
 import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
 
 /**
@@ -213,7 +214,13 @@ public class TileView {
         long width = segment.getContent().getLength();
         long height = segment.getSources().size();
 
-        Color color = sequenceColor(segment.getMutation());
+        Color color;
+        if (segment.getContent() instanceof SegmentStringCollapsed) {
+            color = Color.DARKGRAY;
+        } else {
+            color = sequenceColor(segment.getMutation());
+        }
+
         Point2D topleft = new Point2D(start, index);
 
         VertexView vertex = new VertexView(text, topleft, width, height, scale,

--- a/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
+++ b/lifetiles-graph/src/main/java/nl/tudelft/lifetiles/graph/view/TileView.java
@@ -23,14 +23,22 @@ import nl.tudelft.lifetiles.sequence.model.SequenceSegment;
  *
  */
 public class TileView {
+
     /**
      * Default color of a tile element.
      */
     private static Color defaultColor = Color.web("a1d3ff");
+
+    /**
+     * Color of a collapsed segment.
+     */
+    private static final Color COLLAPSE_COLOR = Color.DARKGRAY;
+
     /**
      * The edges contains all EdgeLines to be displayed.
      */
     private final Group edges;
+
     /**
      * The nodes contains all Vertices to be displayed.
      */
@@ -213,7 +221,13 @@ public class TileView {
         long width = segment.getContent().getLength();
         long height = segment.getSources().size();
 
-        Color color = sequenceColor(segment.getMutation());
+        Color color;
+        if (segment.getContent().isCollapsed()) {
+            color = COLLAPSE_COLOR;
+        } else {
+            color = sequenceColor(segment.getMutation());
+        }
+
         Point2D topleft = new Point2D(start, index);
 
         VertexView vertex = new VertexView(text, topleft, width, height, scale,

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentContent.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentContent.java
@@ -23,4 +23,9 @@ public interface SegmentContent {
      */
     boolean isEmpty();
 
+    /**
+     * @return whether the segment has been collapsed.
+     */
+    boolean isCollapsed();
+
 }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentEmpty.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentEmpty.java
@@ -47,4 +47,12 @@ public class SegmentEmpty implements SegmentContent {
         return true;
     }
 
+    /**
+     * @return whether the segment has been collapsed.
+     */
+    @Override
+    public boolean isCollapsed() {
+        return false;
+    }
+
 }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentString.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentString.java
@@ -47,4 +47,12 @@ public class SegmentString implements SegmentContent {
         return false;
     }
 
+    /**
+     * @return whether the segment has been collapsed.
+     */
+    @Override
+    public boolean isCollapsed() {
+        return false;
+    }
+
 }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
@@ -1,0 +1,72 @@
+package nl.tudelft.lifetiles.sequence.model;
+
+/**
+ * Collapsed SegmentString content.
+ * Used to collapse total segments in the graph.
+ *
+ * @author Jos
+ *
+ */
+public class SegmentStringCollapsed implements SegmentContent {
+
+    /**
+     * The actual content of the collapsed segment string.
+     */
+    private final SegmentContent content;
+
+    /**
+     * The length of the collapsed segment string.
+     */
+    private final long length;
+
+    /**
+     * Constructs a collapsed segment string.
+     *
+     * @param content
+     *            The actual content of the collapsed segment string.
+     */
+    public SegmentStringCollapsed(final SegmentContent content) {
+        this.content = content;
+        this.length = (long) Math.ceil(Math.log(content.getLength())
+                / Math.log(2));
+    }
+
+    /**
+     * @return length of the content of the segment.
+     */
+    @Override
+    public final long getLength() {
+        return length;
+    }
+
+    /**
+     * @return string representation of the collapsed segment.
+     */
+    @Override
+    public final String toString() {
+        return "<" + formatString(content.getLength()) + ">";
+    }
+
+    /**
+     * Formats the string to a base length.
+     *
+     * @param length
+     *            Length of the content of the segment.
+     * @return formatted length of the content of the segment.
+     */
+    private String formatString(final long length) {
+        if (length > 1000) {
+            return Math.ceil(length / 1000) + "kb";
+        }
+        return length + "b";
+    }
+
+    /**
+     * @return that the segment content is an empty node.
+     */
+    @Override
+    public final boolean isEmpty() {
+        return content.isEmpty();
+    }
+
+}

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
@@ -35,7 +35,7 @@ public class SegmentStringCollapsed implements SegmentContent {
      * @return length of the content of the segment.
      */
     @Override
-    public final long getLength() {
+    public long getLength() {
         return length;
     }
 
@@ -43,7 +43,7 @@ public class SegmentStringCollapsed implements SegmentContent {
      * @return string representation of the collapsed segment.
      */
     @Override
-    public final String toString() {
+    public String toString() {
         return "<" + formatString(content.getLength()) + ">";
     }
 
@@ -65,7 +65,7 @@ public class SegmentStringCollapsed implements SegmentContent {
      * @return that the segment content is an empty node.
      */
     @Override
-    public final boolean isEmpty() {
+    public boolean isEmpty() {
         return content.isEmpty();
     }
 

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
@@ -74,4 +74,12 @@ public class SegmentStringCollapsed implements SegmentContent {
         return content.isEmpty();
     }
 
+    /**
+     * @return whether the segment has been collapsed.
+     */
+    @Override
+    public boolean isCollapsed() {
+        return true;
+    }
+
 }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
@@ -10,6 +10,11 @@ package nl.tudelft.lifetiles.sequence.model;
 public class SegmentStringCollapsed implements SegmentContent {
 
     /**
+     * Thousand, used to indicate number of kilo bases.
+     */
+    private static final long THOUSAND = 1000;
+
+    /**
      * The actual content of the collapsed segment string.
      */
     private final SegmentContent content;
@@ -55,8 +60,8 @@ public class SegmentStringCollapsed implements SegmentContent {
      * @return formatted length of the content of the segment.
      */
     private String formatString(final long length) {
-        if (length > 1000) {
-            return (long) Math.ceil(length / 1000) + "kb";
+        if (length > THOUSAND) {
+            return (long) Math.ceil(length / THOUSAND) + "kb";
         }
         return length + "b";
     }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsed.java
@@ -56,7 +56,7 @@ public class SegmentStringCollapsed implements SegmentContent {
      */
     private String formatString(final long length) {
         if (length > 1000) {
-            return Math.ceil(length / 1000) + "kb";
+            return (long) Math.ceil(length / 1000) + "kb";
         }
         return length + "b";
     }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
@@ -25,7 +25,7 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
     /**
      * The content of this segment.
      */
-    private final SegmentContent content;
+    private SegmentContent content;
     /**
      * Contains the sources containing this segment.
      */
@@ -124,6 +124,16 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
         this.mutation = original.getMutation();
         this.referenceStart = original.getReferenceStart();
         this.referenceEnd = original.getReferenceEnd();
+    }
+
+    /**
+     * Change the content of the segment.
+     *
+     * @param content
+     *            new content.
+     */
+    public final void setContent(final SegmentContent content) {
+        this.content = content;
     }
 
     /**
@@ -353,8 +363,8 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
      *
      * @return the interestingness score
      */
-    public double interestingness() {
-        if (content.isEmpty()) {
+    public final double interestingness() {
+        if (content.isEmpty() || content instanceof SegmentStringCollapsed) {
             return 0;
         }
 

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
@@ -132,7 +132,7 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
      * @param content
      *            new content.
      */
-    public final void setContent(final SegmentContent content) {
+    public void setContent(final SegmentContent content) {
         this.content = content;
     }
 
@@ -363,7 +363,7 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
      *
      * @return the interestingness score
      */
-    public final double interestingness() {
+    public double interestingness() {
         if (content.isEmpty() || content instanceof SegmentStringCollapsed) {
             return 0;
         }

--- a/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
+++ b/lifetiles-sequence/src/main/java/nl/tudelft/lifetiles/sequence/model/SequenceSegment.java
@@ -364,7 +364,7 @@ public class SequenceSegment implements Comparable<SequenceSegment> {
      * @return the interestingness score
      */
     public double interestingness() {
-        if (content.isEmpty() || content instanceof SegmentStringCollapsed) {
+        if (content.isEmpty()) {
             return 0;
         }
 

--- a/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsedTest.java
+++ b/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SegmentStringCollapsedTest.java
@@ -1,0 +1,59 @@
+package nl.tudelft.lifetiles.sequence.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SegmentStringCollapsedTest {
+
+    @Test
+    public void lengthSmallestTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(2));
+        assertEquals(1, ssc.getLength());
+    }
+
+    @Test
+    public void lengthSmallTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(8));
+        assertEquals(3, ssc.getLength());
+    }
+
+    @Test
+    public void lengthBigTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(1048576));
+        assertEquals(20, ssc.getLength());
+    }
+
+    @Test
+    public void notEmptyTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentString("XXX"));
+        assertFalse(ssc.isEmpty());
+    }
+
+    @Test
+    public void emptyTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(1048576));
+        assertTrue(ssc.isEmpty());
+    }
+
+    @Test
+    public void smallToStringTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(10));
+        assertEquals("<10b>", ssc.toString());
+    }
+
+    @Test
+    public void bigToStringTest() {
+        SegmentStringCollapsed ssc = new SegmentStringCollapsed(
+                new SegmentEmpty(3000));
+        assertEquals("<3kb>", ssc.toString());
+    }
+}

--- a/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SequenceSegmentTest.java
+++ b/lifetiles-sequence/src/test/java/nl/tudelft/lifetiles/sequence/model/SequenceSegmentTest.java
@@ -173,4 +173,15 @@ public class SequenceSegmentTest {
         assertTrue(v3.interestingness() < v1.interestingness());
         assertTrue(v3.interestingness() > v2.interestingness());
     }
+    @Test
+    public void testSetContent() {
+        v1.setContent(new SegmentEmpty(42));
+        assertEquals(42, v1.getContent().getLength());
+    }
+
+    @Test
+    public void testCollapsedInterestingness() {
+        v1.setContent(new SegmentStringCollapsed(new SegmentEmpty(42)));
+        assertEquals(0, v1.interestingness(), 1E-05);
+    }
 }


### PR DESCRIPTION
Total segments are collapsed to be drawn as vertex views with as text the amount of bases included, for example <102b> and <13kb>.
